### PR TITLE
glt - Update brand to UCSB Courses Search

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -17,7 +17,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
         <Container >
         <img data-testid="AppNavbarImage" src={headerImg} alt="" style={{width: 80, height: 80, marginRight: 10}} />
           <Navbar.Brand as={Link} to="/">
-            Example
+            UCSB Courses Search
           </Navbar.Brand>
 
           <Navbar.Toggle />


### PR DESCRIPTION
In this PR we change the branding from "Example" to "UCSB Courses Search".
![image](https://user-images.githubusercontent.com/72234957/202334568-fa10cdd3-e240-4596-b60d-9b347ef6889d.png)
Closes #7 
