### PR TITLE
bh - Restrict name for Personal Schedule to 15 chars or less

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -59,7 +59,11 @@ function PersonalScheduleForm({ initialPersonalSchedule, submitAction, buttonLab
                     type="text"
                     isInvalid={Boolean(errors.name)}
                     {...register("name", {
-                        required: "Name is required."
+                        required: "Name is required.",
+                        maxLength : {
+                            value: 15,
+                            message: "Max length 15 characters"
+                        }
                     })}
                 />
                 <Form.Control.Feedback type="invalid">


### PR DESCRIPTION
In this PR, we add a restriction to the PersonalSchedule name parameter - name should be 15 characters or less. Closes #8 

<img width="563" alt="image" src="https://user-images.githubusercontent.com/44068328/202337531-144a81d7-6d15-42dc-863e-4559ef69f316.png">
