### PR TITLE
glt - Adjust post method for `/api/courses/post` to prohibit adding primaries that have multiple secondaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,13 @@
             <artifactId>javax.json-api</artifactId>
             <version>1.1.4</version>
         </dependency>
-	  
-
+	<!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
+	<dependency>
+	  <groupId>org.glassfish</groupId>
+	  <artifactId>javax.json</artifactId>
+	  <version>1.1.4</version>
+	</dependency>
+	
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
         </dependency>
+	<dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+	  
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,18 +101,7 @@
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
         </dependency>
-	<dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.1.4</version>
-        </dependency>
-	<!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
-	<dependency>
-	  <groupId>org.glassfish</groupId>
-	  <artifactId>javax.json</artifactId>
-	  <version>1.1.4</version>
-	</dependency>
-	
+
     </dependencies>
 
     <build>

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
@@ -27,7 +27,7 @@ public abstract class ApiController {
     return Map.of("message", message);
   }
 
-  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class, IllegalArgumentException.class })
+  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
     return Map.of(

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
@@ -27,7 +27,7 @@ public abstract class ApiController {
     return Map.of("message", message);
   }
 
-  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class })
+  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class, IllegalArgumentException.class })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
     return Map.of(

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -203,7 +203,7 @@ public class UCSBCurriculumService {
         String url = ALL_SECTIONS_ENDPOINT;
 
 
-        logger.info("url=" + url);
+        log.info("url=" + url);
 
         String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
         .queryParam("quarter", "{quarter}")
@@ -231,7 +231,7 @@ public class UCSBCurriculumService {
             retVal = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
         }
 
-        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
     }
      

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -145,6 +145,10 @@ public class UCSBCurriculumService {
         return retVal;
     }
 
+    /**
+     * This method retrieves exactly one section matching the
+     *  enrollCode and quarter arguments, if such a section exists.
+     */
     public String getSection(String enrollCode, String quarter) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -190,6 +194,12 @@ public class UCSBCurriculumService {
         return retVal;
     }
 
+    /**
+     * This method retrieves all of the sections related to a certain
+     *  enroll code. For example, if the enrollCode is for a discussion
+     *  section, the lecture section and all related discussion sections
+     *  will also be returned.
+     */
     public String getAllSections(String enrollCode, String quarter) {
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -59,6 +59,8 @@ public class UCSBCurriculumService {
 
     public static final String SECTION_ENDPOINT = "https://api.ucsb.edu/academics/curriculums/v1/classsection/{quarter}/{enrollcode}";
 
+    public static final String ALL_SECTIONS_ENDPOINT = "https://api.ucsb.edu/academics/curriculums/v3/classes/{quarter}/{enrollcode}";
+
     public String getJSON(String subjectArea, String quarter, String courseLevel) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -153,6 +155,51 @@ public class UCSBCurriculumService {
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         String url = SECTION_ENDPOINT;
+
+
+        logger.info("url=" + url);
+
+        String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
+        .queryParam("quarter", "{quarter}")
+        .queryParam("enrollcode", "{enrollcode}")
+        .encode()
+        .toUriString();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("quarter", quarter);
+        params.put("enrollcode", enrollCode);
+
+        String retVal = "";
+        MediaType contentType = null;
+        HttpStatus statusCode = null;
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class, params);
+            contentType = re.getHeaders().getContentType();
+            statusCode = re.getStatusCode();
+            retVal = re.getBody();
+        } catch (HttpClientErrorException e) {
+            retVal = "{\"error\": \"401: Unauthorized\"}";
+        }
+
+        if(retVal.equals("null")){
+            retVal = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
+        }
+
+        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+        return retVal;
+    }
+
+    public String getAllSections(String enrollCode, String quarter) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-version", "3.0");
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        String url = ALL_SECTIONS_ENDPOINT;
 
 
         logger.info("url=" + url);

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -372,7 +372,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
         MvcResult response = mockMvc.perform(
                 post("/api/courses/post?enrollCd=63370&psId=1")
                         .with(csrf()))
-                .andExpect(status().isNotFound()).andReturn();
+                .andExpect(status().is(400)).andReturn();
 
         // assert
 	Map<String, Object> json = responseToJson(response);
@@ -394,7 +394,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
         MvcResult response = mockMvc.perform(
                 post("/api/courses/post?enrollCd=63370&psId=1")
                         .with(csrf()))
-                .andExpect(status().isNotFound()).andReturn();
+                .andExpect(status().is(400)).andReturn();
 
         // assert
 	Map<String, Object> json = responseToJson(response);

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -9,6 +9,7 @@ import edu.ucsb.cs156.courses.repositories.PSCourseRepository;
 import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
 import edu.ucsb.cs156.courses.entities.PersonalSchedule;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.documents.SectionFixtures;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -327,27 +328,85 @@ public class PSCourseControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "USER" })
     @Test
-    public void api_courses_post__user_logged_in() throws Exception {
+    public void api_courses_post__user_logged_in__primary_enroll_code() throws Exception {
         // arrange
         User u = currentUserService.getCurrentUser().getUser();
 
-        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20224").user(u).id(1L).build();
+        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20221").user(u).id(1L).build();
         when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
+	when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC291A);
 
-        PSCourse expectedCourses = PSCourse.builder().enrollCd("08268").psId(1L).user(u).id(0L).build();
-        when(coursesRepository.save(eq(expectedCourses))).thenReturn(expectedCourses);
+        PSCourse expectedPrimary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(0L).build();
+        when(coursesRepository.save(eq(expectedPrimary))).thenReturn(expectedPrimary);
+        
 
-        when(ucsbCurriculumService.getSection(eq("08268"), eq("20224"))).thenReturn("API OUTPUT");
-
+	ArrayList<PSCourse> expectedCourses = new ArrayList<>();
+	expectedCourses.add(expectedPrimary);
 
         // act
         MvcResult response = mockMvc.perform(
-                post("/api/courses/post?enrollCd=08268&psId=1")
+                post("/api/courses/post?enrollCd=08896&psId=1")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
-        verify(coursesRepository, times(1)).save(expectedCourses);
+        verify(coursesRepository, times(1)).save(expectedPrimary);
+        String expectedJson = mapper.writeValueAsString(expectedCourses);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_courses_post__user_logged_in__primary_enroll_code_has_one_secondary() throws Exception {
+        // arrange
+        User u = currentUserService.getCurrentUser().getUser();
+
+        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20221").user(u).id(1L).build();
+        when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
+        when(ucsbCurriculumService.getAllSections(eq("63370"), eq("20221"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC100);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/courses/post?enrollCd=63370&psId=1")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+	Map<String, Object> json = responseToJson(response);
+	assertEquals("63370 is for a course with sections; please add a specific section and the lecture will be automatically added", json.get("message"));
+        assertEquals("IllegalArgumentException", json.get("type"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_courses_post__user_logged_in__secondary_enroll_code_adds_secondary_and_primary() throws Exception {
+        // arrange
+        User u = currentUserService.getCurrentUser().getUser();
+
+        PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20221").user(u).id(1L).build();
+        when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
+        when(ucsbCurriculumService.getAllSections(eq("63388"), eq("20221"))).thenReturn(SectionFixtures.SECTION_JSON_CMPSC100);
+
+	PSCourse expectedPrimary = PSCourse.builder().enrollCd("63370").psId(1L).user(u).id(0L).build();
+        when(coursesRepository.save(eq(expectedPrimary))).thenReturn(expectedPrimary);
+
+	PSCourse expectedSecondary = PSCourse.builder().enrollCd("63388").psId(1L).user(u).id(0L).build();
+        when(coursesRepository.save(eq(expectedSecondary))).thenReturn(expectedSecondary);
+
+	ArrayList<PSCourse> expectedCourses = new ArrayList<>();
+	expectedCourses.add(expectedSecondary);
+	expectedCourses.add(expectedPrimary);
+	
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/courses/post?enrollCd=63388&psId=1")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+	verify(coursesRepository, times(1)).save(expectedPrimary);
+	verify(coursesRepository, times(1)).save(expectedSecondary);
         String expectedJson = mapper.writeValueAsString(expectedCourses);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
@@ -362,7 +421,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
         PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20224").user(u).id(1L).build();
         when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
 
-        when(ucsbCurriculumService.getSection(eq("test"), eq("20224"))).thenReturn("{\"error\": \"Enroll code doesn't exist in that quarter.\"}");
+        when(ucsbCurriculumService.getAllSections(eq("test"), eq("20224"))).thenReturn("{\"error\": \"Enroll code doesn't exist in that quarter.\"}");
 
         // act
         MvcResult response = mockMvc.perform(
@@ -385,7 +444,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
         PersonalSchedule personalschedule1 = PersonalSchedule.builder().name("Test").description("Test").quarter("20224").user(u).id(1L).build();
         when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(personalschedule1));
 
-        when(ucsbCurriculumService.getSection(eq("test"), eq("20224"))).thenReturn("{\"error\": \"401: Unauthorized\"}");
+        when(ucsbCurriculumService.getAllSections(eq("test"), eq("20224"))).thenReturn("{\"error\": \"401: Unauthorized\"}");
 
         // act
         MvcResult response = mockMvc.perform(

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
@@ -82,8 +82,8 @@ public class SectionFixtures {
       "generalEducation": [],
       "classSections": [
         {
-          "enrollCode": "63388",
-          "section": "0101",
+          "enrollCode": "63370",
+          "section": "0100",
           "session": null,
           "classClosed": null,
           "courseCancelled": null,
@@ -117,8 +117,8 @@ public class SectionFixtures {
           ]
 	},
 	{
-          "enrollCode": "63370",
-          "section": "0100",
+          "enrollCode": "63388",
+          "section": "0101",
           "session": null,
           "classClosed": null,
           "courseCancelled": null,
@@ -151,6 +151,100 @@ public class SectionFixtures {
             }
           ]
         }
+      ]
+    }
+          """;
+    public static final String SECTION_JSON_CMPSC100_REVERSED = """ 
+    {
+      "quarter": "20221",
+      "courseId": "CMPSC   100  ",
+      "title": "INTRO TEACH METHODS",
+      "contactHours": 30,
+      "description": "Designed to train outstanding undergraduates for learning assistant positio ns in CS courses. Lecture/discussion surveys current research and best prac tices in CS pedagogy including student development theories, different peda gogical techniques, and methods for assessing learning. Students gain exper ience working one-on-one with students, fostering positive learning environ ments, and providing feedback on student work. Students who successfully co mplete this course will earn units by serving as an apprentice undergraduat e learning assistant.",
+      "college": "ENGR",
+      "objLevelCode": "U",
+      "subjectArea": "CMPSC   ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": "L",
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "CMPSC",
+      "generalEducation": [],
+      "classSections": [
+	{
+          "enrollCode": "63388",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 18,
+          "maxEnroll": 25,
+          "secondaryStatus": "R",
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": true,
+          "restrictionLevel": null,
+          "restrictionMajor": null,
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3526",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "    F  ",
+              "beginTime": "12:30",
+              "endTime": "13:45"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "MIRZA D",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+	},
+        {
+          "enrollCode": "63370",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 18,
+          "maxEnroll": 25,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": true,
+          "restrictionLevel": null,
+          "restrictionMajor": null,
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "  W    ",
+              "beginTime": "09:00",
+              "endTime": "11:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "MIRZA D",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+	}
       ]
     }
           """;

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
@@ -56,10 +56,338 @@ public class SectionFixtures {
               "functionCode": "Teaching and in charge"
             }
           ]
-        }
+		}
       ]
     }
       """;
+  public static final String SECTION_JSON_CMPSC100 = """ 
+    {
+      "quarter": "20221",
+      "courseId": "CMPSC   100  ",
+      "title": "INTRO TEACH METHODS",
+      "contactHours": 30,
+      "description": "Designed to train outstanding undergraduates for learning assistant positio ns in CS courses. Lecture/discussion surveys current research and best prac tices in CS pedagogy including student development theories, different peda gogical techniques, and methods for assessing learning. Students gain exper ience working one-on-one with students, fostering positive learning environ ments, and providing feedback on student work. Students who successfully co mplete this course will earn units by serving as an apprentice undergraduat e learning assistant.",
+      "college": "ENGR",
+      "objLevelCode": "U",
+      "subjectArea": "CMPSC   ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": "L",
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "CMPSC",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "63388",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 18,
+          "maxEnroll": 25,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": true,
+          "restrictionLevel": null,
+          "restrictionMajor": null,
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "  W    ",
+              "beginTime": "09:00",
+              "endTime": "11:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "MIRZA D",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+	},
+	{
+          "enrollCode": "63370",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 18,
+          "maxEnroll": 25,
+          "secondaryStatus": "R",
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": true,
+          "restrictionLevel": null,
+          "restrictionMajor": null,
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3526",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "    F  ",
+              "beginTime": "12:30",
+              "endTime": "13:45"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "MIRZA D",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+      ]
+    }
+          """;
+  public static final String SECTION_JSON_CMPSC156 = """
+    {
+      "quarter": "20221",
+      "courseId": "CMPSC   156  ",
+      "title": "ADV APP PROGRAM",
+      "contactHours": 30,
+      "description": "Advanced application programming using a high-level, virtual-machine-based language. Topics include generic programming, exception handling, automatic memory management, and application development, management, and maintenanc e tools, third-party library use, version control, software testing, issue tracking, code review, and working with legacy code.",
+      "college": "ENGR",
+      "objLevelCode": "U",
+      "subjectArea": "CMPSC   ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": "L",
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "CMPSC",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "08292",
+          "section": "0100",
+          "session": null,
+          "classClosed": "Y",
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 72,
+          "maxEnroll": 72,
+          "secondaryStatus": "R",
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1431",
+              "building": "SH",
+              "roomCapacity": 76,
+              "days": "M W    ",
+              "beginTime": "12:30",
+              "endTime": "13:45"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "CONRAD P T",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        },
+        {
+          "enrollCode": "08300",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 24,
+          "maxEnroll": 24,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": " T     ",
+              "beginTime": "17:00",
+              "endTime": "17:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "LU A H",
+              "functionCode": "Teaching but not in charge"
+            },
+            {
+              "instructor": "HEFFERNAN K J",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        },
+        {
+          "enrollCode": "08318",
+          "section": "0102",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 24,
+          "maxEnroll": 24,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": " T     ",
+              "beginTime": "18:00",
+              "endTime": "18:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "HEFFERNAN K J",
+              "functionCode": "Teaching but not in charge"
+            },
+            {
+              "instructor": "LU A H",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        },
+        {
+          "enrollCode": "08326",
+          "section": "0103",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 24,
+          "maxEnroll": 24,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "3525",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": " T     ",
+              "beginTime": "19:00",
+              "endTime": "19:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "LU A H",
+              "functionCode": "Teaching but not in charge"
+            },
+            {
+              "instructor": "HEFFERNAN K J",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        }
+      ]
+    }
+    """;
 
+  public static final String SECTION_JSON_CMPSC291A = """
+    {
+      "quarter": "20221",
+      "courseId": "CMPSC   291A ",
+      "title": "SPEC TOPIC APPS GEN",
+      "contactHours": 30,
+      "description": "These courses provide for the study of topics of current   interest in computer science applications.",
+      "college": "ENGR",
+      "objLevelCode": "G",
+      "subjectArea": "CMPSC   ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": "L",
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "CMPSC",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "08896",
+          "section": "0200",
+          "session": null,
+          "classClosed": "Y",
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 5,
+          "maxEnroll": 10,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "G",
+          "restrictionMajor": "+CMPSC",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "2510",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "M W    ",
+              "beginTime": "13:00",
+              "endTime": "14:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "YAN L",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+      ]
+    }
+    """;
 }
-  

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
@@ -154,7 +154,7 @@ public class SectionFixtures {
       ]
     }
           """;
-  public static final String SECTION_JSON_CMPSC156 = """
+  public static final String SECTION_JSON_CMPSC156_UNEXPECTED = """
     {
       "quarter": "20221",
       "courseId": "CMPSC   156  ",
@@ -175,41 +175,6 @@ public class SectionFixtures {
       "deptCode": "CMPSC",
       "generalEducation": [],
       "classSections": [
-        {
-          "enrollCode": "08292",
-          "section": "0100",
-          "session": null,
-          "classClosed": "Y",
-          "courseCancelled": null,
-          "gradingOptionCode": null,
-          "enrolledTotal": 72,
-          "maxEnroll": 72,
-          "secondaryStatus": "R",
-          "departmentApprovalRequired": false,
-          "instructorApprovalRequired": false,
-          "restrictionLevel": null,
-          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
-          "restrictionMajorPass": null,
-          "restrictionMinor": null,
-          "restrictionMinorPass": null,
-          "concurrentCourses": [],
-          "timeLocations": [
-            {
-              "room": "1431",
-              "building": "SH",
-              "roomCapacity": 76,
-              "days": "M W    ",
-              "beginTime": "12:30",
-              "endTime": "13:45"
-            }
-          ],
-          "instructors": [
-            {
-              "instructor": "CONRAD P T",
-              "functionCode": "Teaching and in charge"
-            }
-          ]
-        },
         {
           "enrollCode": "08300",
           "section": "0101",
@@ -246,6 +211,41 @@ public class SectionFixtures {
             {
               "instructor": "HEFFERNAN K J",
               "functionCode": "Teaching but not in charge"
+            }
+          ]
+        },
+	{
+          "enrollCode": "08292",
+          "section": "0100",
+          "session": null,
+          "classClosed": "Y",
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 72,
+          "maxEnroll": 72,
+          "secondaryStatus": "R",
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1431",
+              "building": "SH",
+              "roomCapacity": 76,
+              "days": "M W    ",
+              "beginTime": "12:30",
+              "endTime": "13:45"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "CONRAD P T",
+              "functionCode": "Teaching and in charge"
             }
           ]
         },
@@ -355,6 +355,66 @@ public class SectionFixtures {
         {
           "enrollCode": "08896",
           "section": "0200",
+          "session": null,
+          "classClosed": "Y",
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 5,
+          "maxEnroll": 10,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "G",
+          "restrictionMajor": "+CMPSC",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "2510",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "M W    ",
+              "beginTime": "13:00",
+              "endTime": "14:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "YAN L",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+      ]
+    }
+    """;
+    
+    public static final String SECTION_JSON_CMPSC291A_UNEXPECTED = """
+    {
+      "quarter": "20221",
+      "courseId": "CMPSC   291A ",
+      "title": "SPEC TOPIC APPS GEN",
+      "contactHours": 30,
+      "description": "These courses provide for the study of topics of current   interest in computer science applications.",
+      "college": "ENGR",
+      "objLevelCode": "G",
+      "subjectArea": "CMPSC   ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": "L",
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "CMPSC",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "08896",
+          "section": "0201",
           "session": null,
           "classClosed": "Y",
           "courseCancelled": null,

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
@@ -450,4 +450,64 @@ public class SectionFixtures {
       ]
     }
     """;
+
+    public static final String SECTION_JSON_CMPSC291A_WRONG_ENROLL_CODE = """
+    {
+      "quarter": "20221",
+      "courseId": "CMPSC   291A ",
+      "title": "SPEC TOPIC APPS GEN",
+      "contactHours": 30,
+      "description": "These courses provide for the study of topics of current   interest in computer science applications.",
+      "college": "ENGR",
+      "objLevelCode": "G",
+      "subjectArea": "CMPSC   ",
+      "unitsFixed": 4,
+      "unitsVariableHigh": null,
+      "unitsVariableLow": null,
+      "delayedSectioning": null,
+      "inProgressCourse": null,
+      "gradingOption": "L",
+      "instructionType": "LEC",
+      "onLineCourse": false,
+      "deptCode": "CMPSC",
+      "generalEducation": [],
+      "classSections": [
+        {
+          "enrollCode": "11111",
+          "section": "0200",
+          "session": null,
+          "classClosed": "Y",
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 5,
+          "maxEnroll": 10,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "G",
+          "restrictionMajor": "+CMPSC",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "2510",
+              "building": "PHELP",
+              "roomCapacity": null,
+              "days": "M W    ",
+              "beginTime": "13:00",
+              "endTime": "14:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "YAN L",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+      ]
+    }
+    """;
 }

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -326,4 +326,68 @@ public class UCSBCurriculumServiceTests {
         assertEquals(expectedResult, result);
     }
 
+    @Test
+    public void test_getAllSections_success() throws Exception {
+        String expectedResult = SectionFixtures.SECTION_JSON_CMPSC165B;
+        //String expectedResult = "expected Result";
+
+        String enrollCode = "08268";
+        String quarter = "20224";
+
+        String expectedURL = UCSBCurriculumService.ALL_SECTIONS_ENDPOINT.replace("{quarter}", quarter).replace("{enrollcode}", enrollCode);
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "3.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getAllSections(enrollCode, quarter);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getAllSections_exception() throws Exception {
+        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+
+
+        String enrollCode = "08268";
+        String quarter = "20224";
+
+        String expectedURL = UCSBCurriculumService.ALL_SECTIONS_ENDPOINT.replace("{quarter}", quarter).replace("{enrollcode}", enrollCode);
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "3.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withUnauthorizedRequest());
+
+        String result = ucs.getAllSections(enrollCode, quarter);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getAllSections_not_found() throws Exception {
+        String expectedResult = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
+
+
+        String enrollCode = "08268";
+        String quarter = "00000";
+
+        String expectedURL = UCSBCurriculumService.ALL_SECTIONS_ENDPOINT.replace("{quarter}", quarter).replace("{enrollcode}", enrollCode);
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "3.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+        String result = ucs.getAllSections(enrollCode, quarter);
+        assertEquals(expectedResult, result);
+    }
+
 }


### PR DESCRIPTION
# Overview

Update:  Successfully deployed on Heroku QA at f22-5pm-2-courses.

Closes #17 

In this PR, our goal is to change the backend endpoint `POST /api/courses/post` to match the functionality of GOLD.  GOLD distinguishes between "primary" sections such as lectures and "secondary" sections such as discussion sections.  For any enroll code the user requests to add, there are three cases:

1.  The enroll code is for a secondary.
2. The enroll code is for a primary without any secondaries.
3. The enroll code is for a primary with (multiple?) secondaries.

In each case, we take the corresponding action:

1. Add the secondary and its primary.  E.g. automatically add the lecture that goes with a discussion section.
2. Add the primary alone.  This is for classes without discussions, for example.
3. You are forbidden from signing up for a lecture without a discussion section.  We have to throw `IllegalArgumentException`.

# How to test

1. Checkout the branch `Geordie-postCourses`.
2. Build and run.
3. Login with OAuth.
4. Load subjects and create a personal schedule (remember your psId).
5. Go to Swagger and under `ps-course-controller` find the endpoint `POST /api/courses/post`.
![image](https://user-images.githubusercontent.com/72234957/202951317-f0585713-7fbf-4766-b7a3-0db852e00dae.png)

6. Now try testing each of the three cases with some enroll codes. (You can find enroll codes fitting each case on the main page
![image](https://user-images.githubusercontent.com/72234957/202951249-1c5f8cb5-14af-4e78-9775-2569803ce7d5.png)

# Guide to the code

In hindsight, it might have been better to split this into two issues, because in order to implement the originally requested feature, I added another feature to another part of the program.

`pom.xml` - Accidentally updated with some dependencies before I realized that the project already has a JSON library.  Do not look at some early commits because they may have used another library.

`ApiController.java` - Updated to include IllegalArgumentException handling.

`UCSBCurriculumService.java` - The existing `postCourses` method that we have to update uses a method `getSection` from this class, where `getSection` corresponds to a UCSB API endpoint.  The problem is that this endpoint doesn't provide the "related" sections to a given section's enroll code.  E.g., the returned JSON only has one section.  There is another endpoint in the UCSB API that *does* have this feature, so I created a new method `getAllSections` that gets data from that endpoint.  I think that this additional feature is justified because without it, finding the related sections would require us to scan through many irrelevant sections provided by the existing endpoints.  I also did not outright replace `getSection`'s implementation with a new one, because I don't know what consequences it would have on other code in the project.  Therefore, I introduced a new method called `getAllSections`.

`PSCourseController.java` - This contains the updated implementation of `postCourses` using the new `getAllSections`.  Note that when the output from the UCSB is unexpected/malformed, the behavior defaults to the old `postCourses`, and the enroll code is just treated as a primary. (We could also throw some exception maybe? Idk what kind.) Probably doesn't matter as long as the UCSB API is reliable.

`UCSBCurriculumServiceTests.java` - Almost a copy/paste of the existing `getSection` tests.  The tests ensure that the new method fails properly when given bad inputs.

`SectionFixtures` - I initially added three example fixtures corresponding to each of the three cases previously described.  Later, it turned out that I needed several more variations to get proper coverage given all the branches in the new feature.  Several of these variations are unusual, in that it doesn't make sense for the UCSB API to output them.

`PSCourseControllerTests.java` - There are several tests.  There are three corresponding to the main three cases and a few more corresponding to edge cases that probably cannot occur.

# Note for future corresponding delete endpoint
When we have to implement the corresponding delete endpoint that removes a primary and secondary together, you can probably reuse `getAllSections` to make your life easier.