### PR TITLE
my - BACKEND - personal schedules must have unique name and quarter

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
@@ -35,4 +35,13 @@ public abstract class ApiController {
       "message", e.getMessage()
     );
   }
+  
+  @ExceptionHandler({IllegalArgumentException.class })
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public Object handleIllegalArgumentException(Throwable e) {
+    return Map.of(
+      "type", e.getClass().getSimpleName(),
+      "message", e.getMessage()
+    );
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -81,7 +81,7 @@ public class PersonalSchedulesController extends ApiController {
     @ApiOperation(value = "Create a new personal schedule")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
-    public Object postSchedule(
+    public PersonalSchedule postSchedule(
             @ApiParam("name") @RequestParam String name,
             @ApiParam("description") @RequestParam String description,
             @ApiParam("quarter") @RequestParam String quarter) {
@@ -100,7 +100,6 @@ public class PersonalSchedulesController extends ApiController {
         }
         PersonalSchedule savedPersonalSchedule = personalscheduleRepository.save(personalschedule);
         return savedPersonalSchedule;
-        
     }
 
     @ApiOperation(value = "Delete a personal schedule owned by this user")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -81,7 +81,7 @@ public class PersonalSchedulesController extends ApiController {
     @ApiOperation(value = "Create a new personal schedule")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
-    public PersonalSchedule postSchedule(
+    public Object postSchedule(
             @ApiParam("name") @RequestParam String name,
             @ApiParam("description") @RequestParam String description,
             @ApiParam("quarter") @RequestParam String quarter) {
@@ -93,8 +93,14 @@ public class PersonalSchedulesController extends ApiController {
         personalschedule.setName(name);
         personalschedule.setDescription(description);
         personalschedule.setQuarter(quarter);
+
+        Optional<PersonalSchedule> existCheck = personalscheduleRepository.findByUserAndNameAndQuarter(currentUser.getUser(), name, quarter);
+        if (existCheck.isPresent()) {
+          throw new IllegalArgumentException("already exists");
+        }
         PersonalSchedule savedPersonalSchedule = personalscheduleRepository.save(personalschedule);
         return savedPersonalSchedule;
+        
     }
 
     @ApiOperation(value = "Delete a personal schedule owned by this user")

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/PersonalScheduleRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/PersonalScheduleRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface PersonalScheduleRepository extends CrudRepository<PersonalSchedule, Long> {
   Optional<PersonalSchedule> findByIdAndUser(long id, User user);
   Iterable<PersonalSchedule> findAllByUserId(Long user_id);
+  Optional<PersonalSchedule> findByUserAndNameAndQuarter(User user, String name, String quarter);
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.jca.endpoint.GenericMessageEndpointFactory;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -556,4 +557,23 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         assertEquals("PersonalSchedule with id 77 not found", json.get("message"));
     }
 
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void cannot_add_two_personal_schedules_with_same_name_and_quarter() throws Exception {
+        // arrange
+
+        User thisUser = currentUserService.getCurrentUser().getUser();
+
+        PersonalSchedule expectedSchedule = PersonalSchedule.builder().name("TestName").description("uniquedescription1").quarter("20222").user(thisUser).id(0L).build();
+        when(personalscheduleRepository.findByUserAndNameAndQuarter(thisUser, "TestName", "20222")).thenReturn(Optional.of(expectedSchedule));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/personalschedules/post?name=TestName&description=uniquedescrition1&quarter=20222")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("already exists", json.get("message"));
+    }
 }


### PR DESCRIPTION
# Overview

Closes #4 

This PR modifies `POST /api/personalschedules/post` such that it no longer allow users to create a personal schedule with a name and quarter that already exists within the database. 

PR achieves this by modifying or creating the following methods:
- `PersonalSchedulesController.postSchedule()`
- `PersonalSchedulRepository.findByUserAndNameAndQuarter()`

Given a personal schedule user, name, description, and quarter, the `postSchedule` method within `PersonalSchedulesController.java` uses newly implemented method `PersonalSchedulRepository.findByUserAndNameAndQuarter` to check the existing database for any other personal schedule created by the same user with the same name and quarter.

If such a personal schedule exists, the request returns an `IllegalArgumentException` with message `already exists`. Newly implemented method `ApiController.handleIllegalArgumentException()` catches this exception and returns the following json:

```
{
   "type" :  "IllegalArgumentException"
   "message" : "already exists"
}
```

If such a personal schedule does not exist, the method follows its original function and simply saves the new personal schedule to the database. 

# Test
1. Checkout branch `Michael-BackendUniqueScheduleName`.
2. Build and run.
3. Login with Google OAuth
4. Open the `personal-schedules-controller` endpoint on Swagger UI, then submit POST requests with `/api/personalschedules/post`.

![image](https://user-images.githubusercontent.com/91687499/203456093-9a236aa2-b67c-4d7d-9eb6-a3a510d8b435.png)

The above image shows that, in Swagger UI, the backend properly stores a new, unique personal schedule.

![image](https://user-images.githubusercontent.com/91687499/203456225-567aaa35-209d-4b1f-ae63-9ea129f52b01.png)

The above image shows that, in Swagger UI, attempting to post another personal schedule with the same name and quarter results in an error message. 

![image](https://user-images.githubusercontent.com/91687499/203456594-51e2b930-5edb-40fb-bdf0-2012e81b8836.png)

The above image also demonstrates that using `/api/personalschedules/all` to return all existing personal schedules verifies the fact that the duplicate personal schedule is not stored.
