### PR TITLE
Peter - Add PersonalSections Table Component and tests.

### DIFF
--- a/frontend/src/fixtures/personalSectionsFixtures.js
+++ b/frontend/src/fixtures/personalSectionsFixtures.js
@@ -1,0 +1,146 @@
+const personalSectionsFixtures = {
+    threePersonalSections:
+    [
+        {
+            "quarter": "20221",
+            "courseId": "ECE       1A ",
+            "title": "COMP ENGR SEMINAR",
+            "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+            "classSections": [
+              {
+                "enrollCode": "12583",
+                "section": "0100",
+                "session": null,
+                "classClosed": null,
+                "courseCancelled": null,
+                "gradingOptionCode": null,
+                "enrolledTotal": 84,
+                "maxEnroll": 100,
+                "secondaryStatus": null,
+                "departmentApprovalRequired": false,
+                "instructorApprovalRequired": false,
+                "restrictionLevel": null,
+                "restrictionMajor": "+PRCME+CMPEN",
+                "restrictionMajorPass": null,
+                "restrictionMinor": null,
+                "restrictionMinorPass": null,
+                "concurrentCourses": [],
+                "timeLocations": [
+                  {
+                    "room": "1930",
+                    "building": "BUCHN",
+                    "roomCapacity": "100",
+                    "days": "M      ",
+                    "beginTime": "15:00",
+                    "endTime": "15:50"
+                  }
+                ],
+                "instructors": [
+                  {
+                    "instructor": "WANG L C",
+                    "functionCode": "Teaching and in charge"
+                  }
+                ]
+              }
+            ],
+            "generalEducation": [],
+            "finalExam": null
+          },
+          {
+            "quarter": "20221",
+            "courseId": "ECE      10A ",
+            "title": "FOUNDTN CIRC & SYS",
+            "description": "The objective of the course is to establish the foundations of analog and d igital circuits. The course will introduce the student to the power of abst raction, resistive networks, network analysis, nonlinear analysis and the d igital abstraction.",
+            "classSections": [
+              {
+                "enrollCode": "12641",
+                "section": "0100",
+                "session": null,
+                "classClosed": null,
+                "courseCancelled": null,
+                "gradingOptionCode": null,
+                "enrolledTotal": 18,
+                "maxEnroll": 35,
+                "secondaryStatus": null,
+                "departmentApprovalRequired": false,
+                "instructorApprovalRequired": false,
+                "restrictionLevel": null,
+                "restrictionMajor": "+CMPEN+EE",
+                "restrictionMajorPass": null,
+                "restrictionMinor": null,
+                "restrictionMinorPass": null,
+                "concurrentCourses": [],
+                "timeLocations": [
+                  {
+                    "room": "1445",
+                    "building": "PHELP",
+                    "roomCapacity": "35",
+                    "days": " T R   ",
+                    "beginTime": "17:00",
+                    "endTime": "18:15"
+                  }
+                ],
+                "instructors": [
+                  {
+                    "instructor": "BUCKWALTER J",
+                    "functionCode": "Teaching and in charge"
+                  }
+                ]
+              }
+            ],
+            "generalEducation": [],
+            "finalExam": null
+          },
+          {
+            "quarter": "20221",
+            "courseId": "ECE      10AL",
+            "title": "FOUNDTN CIRC LAB",
+            "description": "The goal of 10AL is to provide the student with a hands-on   application of the concepts discussed in ECE 10A. The lab   will introduce the use of microcontrollers as a data   acquisition system, network analysis, resistors, nonlinear   analysis and digital abstraction.",
+            "classSections": [
+              {
+                "enrollCode": "12658",
+                "section": "0100",
+                "session": null,
+                "classClosed": null,
+                "courseCancelled": null,
+                "gradingOptionCode": null,
+                "enrolledTotal": 13,
+                "maxEnroll": 25,
+                "secondaryStatus": null,
+                "departmentApprovalRequired": false,
+                "instructorApprovalRequired": false,
+                "restrictionLevel": null,
+                "restrictionMajor": "+CMPEN+EE",
+                "restrictionMajorPass": null,
+                "restrictionMinor": null,
+                "restrictionMinorPass": null,
+                "concurrentCourses": [],
+                "timeLocations": [
+                  {
+                    "room": "5162C",
+                    "building": "HFH",
+                    "roomCapacity": null,
+                    "days": "    F  ",
+                    "beginTime": "09:00",
+                    "endTime": "11:50"
+                  }
+                ],
+                "instructors": [
+                  {
+                    "instructor": "STEPHANSON B",
+                    "functionCode": "Teaching but not in charge"
+                  },
+                  {
+                    "instructor": "BUCKWALTER J",
+                    "functionCode": "In charge but not teaching"
+                  }
+                ]
+              }
+            ],
+            "generalEducation": [],
+            "finalExam": null
+          }
+    ]
+};
+
+export { personalSectionsFixtures };

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -1,0 +1,61 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
+
+
+export default function PersonalSectionsTable({ personalSections }) {
+
+    const columns = [
+        {
+            Header: 'Course ID',
+            accessor: 'courseId',
+        },
+        {
+            Header: 'Enroll Code',
+            accessor: 'classSections[0].enrollCode',
+        },
+        {
+            Header: 'Section',
+            accessor: 'classSections[0].section',
+        },
+        {
+            Header: 'Title',
+            accessor: 'title',
+        },
+        {
+            Header: 'Enrolled',
+            accessor: (row) => convertToFraction(row.classSections[0].enrolledTotal, row.classSections[0].maxEnroll),
+            id: 'enrolled',
+        },
+        {
+            Header: 'Location',
+            accessor: (row) => formatLocation(row.classSections[0].timeLocations),
+            id: 'location',
+        },
+        {
+            Header: 'Days',
+            accessor: 'classSections[0].timeLocations[0].days',
+        },
+        {
+            Header: 'Time',
+            accessor: (row) => formatTime(row.classSections[0].timeLocations),
+            id: 'time',
+        },
+        {
+            Header: 'Instructor',
+            accessor: (row) => formatInstructors(row.classSections[0].instructors),
+            id: 'instructor',
+        }
+
+    ];
+
+    const testid = "PersonalSectionsTable";
+
+    const columnsToDisplay = columns;
+
+    return <OurTable
+        data={personalSections}
+        columns={columnsToDisplay}
+        testid={testid}
+    />;
+}

--- a/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
+++ b/frontend/src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import PersonalSectionsTable from 'main/components/PersonalSections/PersonalSectionsTable';
+import { personalSectionsFixtures } from 'fixtures/personalSectionsFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/PersonalSections/PersonalSectionsTable',
+    component: PersonalSectionsTable
+};
+
+const Template = (args) => {
+    return (
+        <PersonalSectionsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    personalSections: []
+};
+
+export const ThreeSections = Template.bind({});
+
+ThreeSections.args = {
+    personalSections: personalSectionsFixtures.threePersonalSections
+};
+
+
+export const ThreeSubjectsUser = Template.bind({});
+ThreeSubjectsUser.args = {
+    personalSections: personalSectionsFixtures.threePersonalSections,
+    currentUser: currentUserFixtures.adminUser
+};

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { personalSectionsFixtures } from "fixtures/personalSectionsFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+const mockedMutate = jest.fn();
+
+jest.mock('main/utils/useBackend', () => ({
+    ...jest.requireActual('main/utils/useBackend'),
+    useBackendMutation: () => ({mutate: mockedMutate})
+}));
+
+describe("UserTable tests", () => {
+    const queryClient = new QueryClient();
+  
+    test("renders without crashing for empty table with user not logged in", () => {
+      const currentUser = null;
+  
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSectionsTable personalSections={[]} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+    });
+
+    test("renders without crashing for empty table for ordinary user", () => {
+        const currentUser = currentUserFixtures.userOnly;
+    
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <PersonalSectionsTable personalSections={[]} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
+        );
+      });
+
+      test("renders without crashing for empty table for admin", () => {
+        const currentUser = currentUserFixtures.adminUser;
+    
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <PersonalSectionsTable personalSections={[]} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
+        );
+      });
+
+      test("Has the expected column headers and content", async () => {
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+            <PersonalSectionsTable personalSections={personalSectionsFixtures.threePersonalSections}/>
+            </MemoryRouter>
+          </QueryClientProvider>
+          );
+    
+          const expectedHeaders = ["Course ID", "Enroll Code","Section","Title","Enrolled","Location", "Days", "Time", "Instructor"];
+        const expectedFields = ["courseId", "classSections[0].enrollCode","classSections[0].section","title","enrolled","location","classSections[0].timeLocations[0].days","time","instructor"];
+        const testId = "PersonalSectionsTable";
+    
+          expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+          });
+    
+    
+          expectedFields.forEach((field) => {
+            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+            expect(header).toBeInTheDocument();
+          });
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-courseId`)).toHaveTextContent("ECE 1A");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-classSections[0].enrollCode`)).toHaveTextContent("12583");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-classSections[0].section`)).toHaveTextContent("0100");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent("COMP ENGR SEMINAR");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-location`)).toHaveTextContent("BUCHN 1930");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-classSections[0].timeLocations[0].days`)).toHaveTextContent("M");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
+          expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("WANG L C");
+          expect(screen.getByTestId(`${testId}-cell-row-2-col-instructor`)).toHaveTextContent("STEPHANSON B, BUCKWALTER J");
+          
+    
+      });
+});


### PR DESCRIPTION
### This pull request closes Issue #16 Create component to list sections for a Personal Schedule. 

**Which files were changed / add?**

- new file:   src/fixtures/personalSectionsFixtures.js
- new file:   src/main/components/PersonalSections/PersonalSectionsTable.js
- new file:   src/stories/components/PersonalSections/PersonalSectionsTable.stories.js
- new file:   src/tests/components/PersonalSections/PersonalSectionsTable.test.js

**What does this pull request add?**

- Adds the Personal Sections Table component which lists all added courses to a personal schedule. This component will be used on the PersonalSchedules details page.
- Additionally, a test was created to ensure Personal sections table works correctly.

**How can this pull request be tested?**

1. Pull this branch so you can access it locally.
2. cd to the frontend directory in the project file
3. npm run storybook
4. Navigate to http://localhost:6006/?path=/docs/components-personalsections-personalsectionstable--empty
5. Check if table render correctly
6. Optional: Additionally personalSectionsFixtures.js can be modified in order to test different test cases. New test cases can be generated from api/personalSections/all and the response can be copy-pasted into the fixtures. 
_Expected result:_

_Empty Table:_
<img width="1026" alt="Screenshot 2022-11-27 at 2 11 55 PM" src="https://user-images.githubusercontent.com/40444566/204162571-52312791-6568-4dfa-adaa-3c5c045b3027.png">

_Table with 3 entries:_
<img width="1037" alt="Screenshot 2022-11-27 at 2 12 01 PM" src="https://user-images.githubusercontent.com/40444566/204162574-f64f00e1-f32b-43df-a170-91f8d3d96085.png">



