### PR TITLE
bh - better error message in frontend for duplicate personal schedule creation

### DIFF
--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
@@ -20,9 +20,13 @@ export default function PersonalSchedulesCreatePage() {
     toast(`New personalSchedule Created - id: ${personalSchedule.id} name: ${personalSchedule.name}`);
   }
 
+  const onError = (error) => {
+    toast(`Error: ${error.response.data.message}`);
+  }
+
   const mutation = useBackendMutation(
     objectToAxiosParams,
-     { onSuccess }, 
+     { onSuccess, onError }, 
      // Stryker disable next-line all : hard to set up test for caching
      ["/api/personalschedules/all"]
      );

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
@@ -106,13 +106,6 @@ describe("PersonalSchedulesCreatePage tests", () => {
     test("filling the form with a duplicate personal schedule returns an error", async () => {
 
         const queryClient = new QueryClient();
-        const personalSchedule = {
-            id: 18,
-            name: "Duplicate",
-            description: "dupe",
-            quarter: "W08"
-        };
-
         const error = {
             message: "A personal schedule with that name already exists in that quarter",
         };

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
@@ -59,7 +59,6 @@ describe("PersonalSchedulesCreatePage tests", () => {
             description: "desc",
             quarter: "W08"
         };
-
         axiosMock.onPost("/api/personalschedules/post").reply( 202, personalSchedule );
 
         render(
@@ -103,6 +102,62 @@ describe("PersonalSchedulesCreatePage tests", () => {
         expect(mockToast).toBeCalledWith("New personalSchedule Created - id: 17 name: SampName");
         expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
     });
+    
+    test("filling the form with a duplicate personal schedule returns an error", async () => {
 
+        const queryClient = new QueryClient();
+        const personalSchedule = {
+            id: 18,
+            name: "Duplicate",
+            description: "dupe",
+            quarter: "W08"
+        };
 
+        const error = {
+            message: "A personal schedule with that name already exists in that quarter",
+        };
+
+        
+        axiosMock.onPost("/api/personalschedules/post").reply( 404, error );
+        
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("PersonalScheduleForm-name")).toBeInTheDocument();
+        
+        const nameField = screen.getByTestId("PersonalScheduleForm-name");
+        const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
+        const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
+        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+        fireEvent.change(nameField, { target: { value: 'Duplicate' } });
+        fireEvent.change(descriptionField, { target: { value: 'dupe' } });
+        fireEvent.change(quarterField, { target: { value: '20124' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(quarterField).toHaveValue("20124");
+        //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "name": "Duplicate",
+            "description": "dupe",
+            "quarter": "20124"
+        });
+
+        expect(mockToast).toBeCalledWith("Error: A personal schedule with that name already exists in that quarter");
+        // expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
+    });
+
+    
 });

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/ApiController.java
@@ -27,7 +27,7 @@ public abstract class ApiController {
     return Map.of("message", message);
   }
 
-  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class, IllegalArgumentException.class })
+  @ExceptionHandler({ EntityNotFoundException.class, BadEnrollCdException.class })
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
     return Map.of(

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -101,7 +101,7 @@ public class PersonalSchedulesController extends ApiController {
 
         Optional<PersonalSchedule> existCheck = personalscheduleRepository.findByUserAndNameAndQuarter(currentUser.getUser(), name, quarter);
         if (existCheck.isPresent()) {
-          throw new IllegalArgumentException("already exists");
+          throw new IllegalArgumentException("A personal schedule with that name already exists in that quarter");
         }
         PersonalSchedule savedPersonalSchedule = personalscheduleRepository.save(personalschedule);
         return savedPersonalSchedule;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -631,7 +631,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
                 .andExpect(status().isBadRequest()).andReturn();
 
         Map<String, Object> json = responseToJson(response);
-        assertEquals("already exists", json.get("message"));
+        assertEquals("A personal schedule with that name already exists in that quarter", json.get("message"));
 
     }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -567,7 +567,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         MvcResult response = mockMvc.perform(
                 post("/api/personalschedules/post?name=name longer than 15 characters&description=Test Description&quarter=20221")
                         .with(csrf()))
-                .andExpect(status().isNotFound()).andReturn();
+                .andExpect(status().isBadRequest()).andReturn();
 
         // assert
         Map<String, Object> json = responseToJson(response);
@@ -583,7 +583,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         MvcResult response = mockMvc.perform(
                 post("/api/personalschedules/post?name=name longer than 15 characters&description=Test Description&quarter=20221")
                         .with(csrf()))
-                .andExpect(status().isNotFound()).andReturn();
+                .andExpect(status().isBadRequest()).andReturn();
 
         // assert
         Map<String, Object> json = responseToJson(response);


### PR DESCRIPTION
In this PR, we modify the error message to be more user friendly, such that the `useBackendMutation error is not shown`. Instead a more user-friendly message is shown: `A personal schedule with that name already exists in that quarter`. Closes issue #38 

![image](https://user-images.githubusercontent.com/44068328/204413802-d5515b00-8762-4716-ab5a-eb8841c4b729.png)

To test this feature, clone this branch and run `npm start` in the frontend directory. Run `mvn spring-boot:run` in the main directory and navigate to localhost:8080. Login to an admin account and try to create two identical personal schedules.