### PR TITLE
IH: Add query & controller for course-over-time search

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.collections;
 
 import java.util.Optional;
+import java.util.List;
 
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -12,4 +13,11 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 public interface ConvertedSectionCollection extends MongoRepository<ConvertedSection, ObjectId> {
     @Query("{'courseInfo.quarter': ?0, 'section.enrollCode': ?1}")
     Optional<ConvertedSection> findOneByQuarterAndEnrollCode(String quarter, String enrollCode);
+
+    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'courseInfo.courseId': { $regex: ?2 }}")
+    List<ConvertedSection> findByQuarterRangeAndCourseId(
+        String startQuarter,
+        String endQuarter,
+        String courseId );
+    
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import java.util.List;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import io.swagger.annotations.ApiOperation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@RestController
+@RequestMapping("/api/public/courseovertime")
+public class CourseOverTimeController {
+
+    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeController.class);
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @ApiOperation(value = "Get a list of courses over time")
+    @GetMapping(value = "/search", produces = "application/json")
+    public ResponseEntity<String> search(
+        @RequestParam String startQtr,
+        @RequestParam String endQtr,
+        @RequestParam String subjectArea,
+        @RequestParam String courseNumber
+    ) throws JsonProcessingException {
+        List<ConvertedSection> courseResults = convertedSectionCollection.findByQuarterRangeAndCourseId(
+            startQtr,
+            endQtr,
+            makeFormattedCourseId(subjectArea, courseNumber)
+        );
+        String body = mapper.writeValueAsString(courseResults);
+        return ResponseEntity.ok().body(body);
+    }
+
+    String makeFormattedCourseId(String subjectArea, String courseNumber) {
+        String[] nums = courseNumber.split("[a-zA-Z]+");
+        String[] suffs = courseNumber.split("[0-9]+");
+        if (suffs.length < 2) { // no suffix
+            return
+                  String.format( "%-8s", subjectArea                ) // 'CMPSC   '
+                + String.format( "%3s" , nums[0]                    ) // '  8'
+            ;
+        }
+        return
+              String.format( "%-8s", subjectArea                ) // 'CMPSC   '
+            + String.format( "%3s" , nums[0]                    ) // '  8'
+            + String.format( "%-2s", suffs[1]                   ) // 'A '
+        ;
+    }
+    
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -1,0 +1,155 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.Section;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@WebMvcTest(value = CourseOverTimeController.class)
+@Import(SecurityConfig.class)
+@AutoConfigureDataJpa
+public class CourseOverTimeControllerTests {
+    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeControllerTests.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @Test
+    public void test_search_emptyRequest() throws Exception {
+        List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
+        String urlTemplate = "/api/public/courseovertime/search?startQtr=%s&endQtr=%s&subjectArea=%s&courseNumber=%s";
+        
+        String url = String.format(urlTemplate, "20222", "20212", "CMPSC", "130A");
+
+        // mock
+        when(convertedSectionCollection.findByQuarterRangeAndCourseId(any(String.class), any(String.class), any(String.class)))
+            .thenReturn(expectedResult);
+
+        // act
+        MvcResult response = mockMvc.perform(
+            get(url).contentType("application/json")
+        ).andExpect(
+            status().isOk()
+        ).andReturn();
+
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = mapper.writeValueAsString(expectedResult);
+        
+        assertEquals(expectedString, responseString);
+    }
+
+    @Test public void test_search_validRequestWithoutSuffix() throws Exception {
+        CourseInfo info = CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   24 -1")
+            .title("OBJ ORIENTED DESIGN")
+            .description("Intro to object oriented design")
+            .build();
+        
+        Section section1 = new Section();
+
+        Section section2 = new Section();
+
+        ConvertedSection cs1 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section1)
+            .build();
+        
+        ConvertedSection cs2 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section2)
+            .build();
+
+        String urlTemplate = "/api/public/courseovertime/search?startQtr=%s&endQtr=%s&subjectArea=%s&courseNumber=%s";
+    
+        String url = String.format(urlTemplate, "20222", "20222", "CMPSC", "24");
+
+        List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
+        expectedSecs.addAll(Arrays.asList(cs1, cs2));
+
+        // mock
+        when(convertedSectionCollection.findByQuarterRangeAndCourseId(any(String.class), any(String.class), eq("CMPSC    24"))).thenReturn(expectedSecs);
+
+        // act
+        MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+        // assert
+        String expectedString = mapper.writeValueAsString(expectedSecs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedString, responseString);
+    }
+
+    @Test public void test_search_validRequestWithSuffix() throws Exception {
+        CourseInfo info = CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   130A -1")
+            .title("DATA STRUCT AND ALG")
+            .description("Data Structures and Algorithms")
+            .build();
+        
+        Section section1 = new Section();
+
+        Section section2 = new Section();
+
+        ConvertedSection cs1 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section1)
+            .build();
+        
+        ConvertedSection cs2 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section2)
+            .build();
+
+        String urlTemplate = "/api/public/courseovertime/search?startQtr=%s&endQtr=%s&subjectArea=%s&courseNumber=%s";
+    
+        String url = String.format(urlTemplate, "20222", "20222", "CMPSC", "130A");
+
+        List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
+        expectedSecs.addAll(Arrays.asList(cs1, cs2));
+
+        // mock
+        when(convertedSectionCollection.findByQuarterRangeAndCourseId(any(String.class), any(String.class), eq("CMPSC   130A "))).thenReturn(expectedSecs);
+
+        // act
+        MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+        // assert
+        String expectedString = mapper.writeValueAsString(expectedSecs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedString, responseString);
+    }
+
+}


### PR DESCRIPTION
Closes #26 
Closes #27 

This adds a MongoDB query to the `ConvertedSectionCollection` which returns a list of `ConvertedSection`s given a start quarter, an end quarter, and a course ID. It uses Mongo's GTE and LTE (>= and <=) for the quarter range, and regex for the course ID (to get all courses which start with the given ID, so as to include courses with multiple lectures).

This also adds a new controller, the `CourseOverTimeController` which calls the new query. Its only method, `search()`, accessed using the `/api/public/courseovertime/search` endpoint, takes a `startQtr`, `endQtr`, `subjectArea`, and `courseNumber`. All of these are `String`s.

`courseNumber` can contain a letter suffix, or not. If `courseNumber` does not contain a suffix, but the associated courses have suffixes (i.e. `courseNumber = 130` but the available courses are `CMPSC 130A` and `CMPSC 130B`), we will return all courses with the given number and *any* suffix. This is facilitated by the new `makeFormattedCourseId` function, which takes a `subjectArea` and `courseNumber` and returns a properly-formatted `courseId` string, taking into account the possibility of a suffix.

Tested on Heroku using the Swagger UI. The MongoDB database currently only contains S22 ANTH & CMPSC courses, so I tested using CMPSC 130A and CMPSC 24.

Controller endpoint on Swagger (on Heroku) using a course with a suffix (CMPSC 130A):
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/20908336/204469732-cd008d55-9bdc-4b9e-86c3-f2b542d743b7.png">

Response (first lines):
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/20908336/204469858-87f725ac-4347-428a-8101-29ec0d38df06.png">

Using a course without a suffix (CMPSC 24):
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/20908336/204470073-022d5d70-549d-4a55-ad1d-52f8803933d6.png">

Response (first lines):
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/20908336/204470163-31239977-7888-4ec1-9d2f-e6037e5d7339.png">


