### PR TITLE
Peter - Add PersonalSections Table to PersonalSchedulesDetails Page

### DIFF
--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -1,6 +1,7 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import PersonalSchedulesTable from 'main/components/PersonalSchedules/PersonalSchedulesTable';
+import PersonalSectionsTable from 'main/components/PersonalSections/PersonalSectionsTable'
 import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 
 
@@ -20,6 +21,18 @@ export default function PersonalSchedulesDetailsPage() {
       }
     );
 
+    const { data: personalSection} =
+    useBackend(
+        // Stryker disable all : hard to test for query caching
+      [`/api/personalSections/all?psId=${id}`],{
+          method: "GET",
+          url: `/api/personalSections/all?psId=${id}`,
+          params: {
+            id
+          }
+      }
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -28,7 +41,10 @@ export default function PersonalSchedulesDetailsPage() {
                 <PersonalSchedulesTable personalSchedules={[personalSchedule]} showButtons={false} />
             }
             <p>
-                This is where the list of courses will go 
+              <h2>Sections in Personal Schedule</h2>
+                {personalSection &&
+                  <PersonalSectionsTable personalSections={personalSection}/>
+                } 
             </p>
       </div>
     </BasicLayout>

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -65,6 +65,19 @@ describe("PersonalSchedulesDetailsPage tests", () => {
         );
     });
 
+    test("renders without crashing for regular user", () => {
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/personalSections/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PersonalSchedulesDetailsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
     test("shows the correct info for admin users", async() => {
         setupAdminUser();
         const queryClient = new QueryClient();
@@ -88,6 +101,53 @@ describe("PersonalSchedulesDetailsPage tests", () => {
                 "name": "CS156"
               
         });
+        axiosMock.onGet(`api/personalSections/all?psId=17`).reply(200, [
+            {
+              "quarter": "20221",
+              "courseId": "ECE       1A ",
+              "title": "COMP ENGR SEMINAR",
+              "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+              "classSections": [
+                {
+                  "enrollCode": "12583",
+                  "section": "0100",
+                  "session": null,
+                  "classClosed": null,
+                  "courseCancelled": null,
+                  "gradingOptionCode": null,
+                  "enrolledTotal": 84,
+                  "maxEnroll": 100,
+                  "secondaryStatus": null,
+                  "departmentApprovalRequired": false,
+                  "instructorApprovalRequired": false,
+                  "restrictionLevel": null,
+                  "restrictionMajor": "+PRCME+CMPEN",
+                  "restrictionMajorPass": null,
+                  "restrictionMinor": null,
+                  "restrictionMinorPass": null,
+                  "concurrentCourses": [],
+                  "timeLocations": [
+                    {
+                      "room": "1930",
+                      "building": "BUCHN",
+                      "roomCapacity": "100",
+                      "days": "M      ",
+                      "beginTime": "15:00",
+                      "endTime": "15:50"
+                    }
+                  ],
+                  "instructors": [
+                    {
+                      "instructor": "WANG L C",
+                      "functionCode": "Teaching and in charge"
+                    }
+                  ]
+                }
+              ],
+              "generalEducation": [],
+              "finalExam": null
+            }
+          ]);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -100,12 +160,28 @@ describe("PersonalSchedulesDetailsPage tests", () => {
              expect(screen.getByText("PersonalSchedules Details")).toBeInTheDocument();
         });
         await waitFor(()=>{
+            expect(screen.getByText("Sections in Personal Schedule")).toBeInTheDocument();
+       });
+        await waitFor(()=>{
             expect(screen.getByTestId("PersonalSchedulesTable-cell-row-0-col-id")).toHaveTextContent("17");
+       });
+
+       await waitFor(()=>{
+        expect(screen.getByTestId("PersonalSectionsTable-cell-row-0-col-courseId")).toHaveTextContent("ECE 1A");
        });
        
         expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("My Winter Courses");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("CS156");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-classSections[0].enrollCode`)).toHaveTextContent("12583");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-classSections[0].section`)).toHaveTextContent("0100");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-title`)).toHaveTextContent("COMP ENGR SEMINAR");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-enrolled`)).toHaveTextContent("84/100");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-location`)).toHaveTextContent("BUCHN 1930");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-classSections[0].timeLocations[0].days`)).toHaveTextContent("M");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-time`)).toHaveTextContent("3:00 PM - 3:50 PM");
+        expect(screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-instructor`)).toHaveTextContent("WANG L C");
 
     });
 
 });
+

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -65,19 +65,6 @@ describe("PersonalSchedulesDetailsPage tests", () => {
         );
     });
 
-    test("renders without crashing for regular user", () => {
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/personalSections/all").reply(200, []);
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PersonalSchedulesDetailsPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-    });
-
     test("shows the correct info for admin users", async() => {
         setupAdminUser();
         const queryClient = new QueryClient();


### PR DESCRIPTION
### **This pull request closes Issue #19 Add personal schedule details to PersonalScheduleDetailsPage.**


**Which files were modified / added?**

```
modified:   src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
modified:   src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
```

**What does this pull request add?**

 - Adds the Personal Sections Table component which lists all added courses to a personal schedule to the PersonalSchedule Details page.
 - Additionally, a test was created to ensure Personal sections table is rendered correctly on the PersonalSections Details page and works correctly.


### **How can this pull request be tested?**

**TESTING ON HEROKU QA**

See (Deployed on Heroku): https://f22-5pm-2-courses.herokuapp.com/personalschedules/details/24

Results should look like this on Heroku:
<img width="1146" alt="Screenshot 2022-11-28 at 6 03 31 PM" src="https://user-images.githubusercontent.com/40444566/204421559-194a37ae-83d5-4d66-9bb4-fce4dea72cce.png">


Also to further test the feature, add more items to the table! To do this:
 - Go to UCSB Course Search and search for S22 courses in any department. 
 - Find a course 
 - Copy the enrollment code, navigate to PSCourse>Create
 - Paste the enrollment code and enter 24 into the Personal Schedule ID Field
 - Now, Go to PersonalSchedules>List>Details (ID24)
 - Verify that the new Sections have been added

**LOCAL TESTING:**
- Pull this branch so you can access it locally.
- mvn spring-boot:run 
- cd to the frontend directory in the project file
 - npm start
 - Navigate to http://localhost:8080/personalschedules/list
 - Check details of a Personal Schedule to see Sections
 - If empty, populate with steps in Testing in Heroku QA Section

_Expected result when testing Locally:_
<img width="1391" alt="Screenshot 2022-11-28 at 6 07 24 PM" src="https://user-images.githubusercontent.com/40444566/204420912-bbe64ca8-2d35-478b-9cb3-a3f3a384d04d.png">
