### PR TITLE
James backend quartersubjects

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,7 +1,7 @@
-GOOGLE_CLIENT_ID=fillinblank
-GOOGLE_CLIENT_SECRET=GOCSPX-fillinblank
+GOOGLE_CLIENT_ID=see-instructions-in-readme
+GOOGLE_CLIENT_SECRET=see-instructions-in-readme
 ADMIN_EMAILS=phtcon@ucsb.edu
-MONGODB_URI=fillinblank
+MONGODB_URI=see-instructions-in-readme
 START_QTR=20221
 END_QTR=20222
-UCSB_API_KEY=fillinblank
+UCSB_API_KEY=see-instructions-in-readme

--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,7 +1,7 @@
-GOOGLE_CLIENT_ID=see-instructions-in-readme
-GOOGLE_CLIENT_SECRET=see-instructions-in-readme
+GOOGLE_CLIENT_ID=637182550630-rdq64p3djk534u11dmul4dnrlam6rhn8.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=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
 ADMIN_EMAILS=phtcon@ucsb.edu
-MONGODB_URI=see-instructions-in-readme
+MONGODB_URI=mongodb+srv://dbuser:VBDPldGZkRtvIy2I@cluster0.4pfnf1h.mongodb.net/database?retryWrites=true&w=majority
 START_QTR=20221
 END_QTR=20222
-UCSB_API_KEY=see-instructions-in-readme
+UCSB_API_KEY=YatZVSgsIWAQ4GLZRzIgivH5sxvGwA01

--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,7 +1,7 @@
-GOOGLE_CLIENT_ID=637182550630-rdq64p3djk534u11dmul4dnrlam6rhn8.apps.googleusercontent.com
-GOOGLE_CLIENT_SECRET=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
+GOOGLE_CLIENT_ID=fillinblank
+GOOGLE_CLIENT_SECRET=GOCSPX-fillinblank
 ADMIN_EMAILS=phtcon@ucsb.edu
-MONGODB_URI=mongodb+srv://dbuser:VBDPldGZkRtvIy2I@cluster0.4pfnf1h.mongodb.net/database?retryWrites=true&w=majority
+MONGODB_URI=fillinblank
 START_QTR=20221
 END_QTR=20222
-UCSB_API_KEY=YatZVSgsIWAQ4GLZRzIgivH5sxvGwA01
+UCSB_API_KEY=fillinblank

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -45,6 +45,9 @@ public class JobsController extends ApiController {
     ObjectMapper mapper;
 
     @Autowired
+    UpdateCourseDataJobFactory updateCourseDataJobFactory;
+
+    @Autowired
     UpdateCourseDataWithQuarterJobFactory updateCourseDataWithQuarterJobFactory;
 
     @ApiOperation(value = "List all jobs")

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -21,6 +21,8 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJob;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJobFactory;
 import edu.ucsb.cs156.courses.jobs.TestJob;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
@@ -43,7 +45,7 @@ public class JobsController extends ApiController {
     ObjectMapper mapper;
 
     @Autowired
-    UpdateCourseDataJobFactory updateCourseDataJobFactory;
+    UpdateCourseDataWithQuarterJobFactory updateCourseDataWithQuarterJobFactory;
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -83,4 +85,13 @@ public class JobsController extends ApiController {
         return jobService.runAsJob(updateCourseDataJob);
     }
 
+    public Job launchUpdateCourseDataWithQuarterJob(
+        @ApiParam("quarter (YYYYQ format)") @RequestParam String quarterYYYYQ
+    ) {
+       
+        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = updateCourseDataWithQuarterJobFactory.create(
+            quarterYYYYQ);
+
+        return jobService.runAsJob(updateCourseDataWithQuarterJob);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -88,6 +88,9 @@ public class JobsController extends ApiController {
         return jobService.runAsJob(updateCourseDataJob);
     }
 
+    @ApiOperation(value = "Launch Job to Update Course Data using Quarter")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/updateQuarterCourses")
     public Job launchUpdateCourseDataWithQuarterJob(
         @ApiParam("quarter (YYYYQ format)") @RequestParam String quarterYYYYQ
     ) {

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJob.java
@@ -1,0 +1,73 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import java.util.List;
+import java.util.Optional;
+
+
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.services.UCSBSubjectsService;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+
+@AllArgsConstructor
+@Slf4j
+public class UpdateCourseDataWithQuarterJob implements JobContextConsumer {
+
+    @Getter private String quarterYYYYQ;
+    @Getter private UCSBSubjectsService ucsbSubjectService;
+    @Getter private UCSBCurriculumService ucsbCurriculumService;
+    @Getter private ConvertedSectionCollection convertedSectionCollection;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Updating courses for [" + quarterYYYYQ + "]");
+
+        List<UCSBSubject> ucsbsubjects = ucsbSubjectService.get();
+        for (UCSBSubject subject : ucsbsubjects){
+            String subjectArea = subject.getSubjectTranslation();
+        }
+
+        List<ConvertedSection> convertedSections = ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ,
+                "A");
+
+        ctx.log("Found " + convertedSections.size() + " sections");
+        ctx.log("Storing in MongoDB Collection...");
+
+        int newSections = 0;
+        int updatedSections = 0;
+        int errors = 0;
+
+        for (ConvertedSection section : convertedSections) {
+            try {
+                String quarter = section.getCourseInfo().getQuarter();
+                String enrollCode =  section.getSection().getEnrollCode();
+                Optional<ConvertedSection> optionalSection = convertedSectionCollection
+                        .findOneByQuarterAndEnrollCode(quarter,enrollCode);
+                if (optionalSection.isPresent()) {
+                    ConvertedSection existingSection = optionalSection.get();
+                    existingSection.setCourseInfo(section.getCourseInfo());
+                    existingSection.setSection(section.getSection());
+                    convertedSectionCollection.save(existingSection);
+                    updatedSections++;
+                } else {
+                    convertedSectionCollection.save(section);
+                    newSections++;
+                }
+            } catch (Exception e) {
+                ctx.log("Error saving section: " + e.getMessage());
+                errors++;
+            }
+        }
+    
+        ctx.log(String.format("%d new sections saved, %d sections updated, %d errors", newSections, updatedSections,
+                errors));
+        ctx.log("Courses for [" + quarterYYYYQ + "] have been updated");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJob.java
@@ -27,7 +27,7 @@ public class UpdateCourseDataWithQuarterJob implements JobContextConsumer {
 
     @Override
     public void accept(JobContext ctx) throws Exception {
-        ctx.log("Updating courses for [" + quarterYYYYQ + "]");
+        ctx.log("Updating quarter courses for [" + quarterYYYYQ + "]");
 
         List<UCSBSubject> ucsbsubjects = ucsbSubjectService.get();
         for (UCSBSubject subject : ucsbsubjects){
@@ -38,41 +38,41 @@ public class UpdateCourseDataWithQuarterJob implements JobContextConsumer {
             List<ConvertedSection> convertedSections = ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ,
                 "A");
             
-                ctx.log("Found " + convertedSections.size() + " sections");
-                ctx.log("Storing in MongoDB Collection...");
+            ctx.log("Found " + convertedSections.size() + " sections");
+            ctx.log("Storing in MongoDB Collection...");
         
-                int newSections = 0;
-                int updatedSections = 0;
-                int errors = 0;
+            int newSections = 0;
+            int updatedSections = 0;
+            int errors = 0;
         
-                for (ConvertedSection section : convertedSections) {
-                    try {
-                        String quarter = section.getCourseInfo().getQuarter();
-                        String enrollCode =  section.getSection().getEnrollCode();
-                        Optional<ConvertedSection> optionalSection = convertedSectionCollection
+            for (ConvertedSection section : convertedSections) {
+                try {
+                    String quarter = section.getCourseInfo().getQuarter();
+                    String enrollCode =  section.getSection().getEnrollCode();
+                    Optional<ConvertedSection> optionalSection = convertedSectionCollection
                                 .findOneByQuarterAndEnrollCode(quarter,enrollCode);
-                        if (optionalSection.isPresent()) {
-                            ConvertedSection existingSection = optionalSection.get();
-                            existingSection.setCourseInfo(section.getCourseInfo());
-                            existingSection.setSection(section.getSection());
-                            convertedSectionCollection.save(existingSection);
-                            updatedSections++;
-                        } else {
-                            convertedSectionCollection.save(section);
-                            newSections++;
-                        }
-                    } catch (Exception e) {
-                        ctx.log("Error saving section: " + e.getMessage());
-                        errors++;
+                    if (optionalSection.isPresent()) {
+                        ConvertedSection existingSection = optionalSection.get();
+                        existingSection.setCourseInfo(section.getCourseInfo());
+                        existingSection.setSection(section.getSection());
+                        convertedSectionCollection.save(existingSection);
+                        updatedSections++;
+                    } else {
+                        convertedSectionCollection.save(section);
+                        newSections++;
                     }
+                } catch (Exception e) {
+                    ctx.log("Error saving section: " + e.getMessage());
+                    errors++;
                 }
+            }
             
-                ctx.log(String.format("%d new sections saved, %d sections updated, %d errors", newSections, updatedSections,
+            ctx.log(String.format("%d new sections saved, %d sections updated, %d errors", newSections, updatedSections,
                         errors));
-                ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
+            ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
         }
 
-        ctx.log("Courses for [ " + quarterYYYYQ + "] have been updated");
+        ctx.log("Quarter courses for [" + quarterYYYYQ + "] have been updated");
 
     }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactory.java
@@ -20,6 +20,6 @@ public class UpdateCourseDataWithQuarterJobFactory  {
     public UpdateCourseDataWithQuarterJob create(String quarterYYYYQ) {
         log.info("ucsbCurriculumService = " + ucsbCurriculumService);
         log.info("convertedSectionCollection = " + convertedSectionCollection);
-        return new UpdateCourseDataWithQuarterJob(quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
+        return new UpdateCourseDataWithQuarterJob(quarterYYYYQ, convertedSectionCollection);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactory.java
@@ -5,11 +5,15 @@ import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.UCSBSubjectsService;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
 public class UpdateCourseDataWithQuarterJobFactory  {
+
+    @Autowired
+    private UCSBSubjectsService ucsbSubjectService;
 
     @Autowired
     private UCSBCurriculumService ucsbCurriculumService;
@@ -18,8 +22,9 @@ public class UpdateCourseDataWithQuarterJobFactory  {
     private ConvertedSectionCollection convertedSectionCollection;
 
     public UpdateCourseDataWithQuarterJob create(String quarterYYYYQ) {
+        log.info("ucsbSubjectService = " + ucsbSubjectService);
         log.info("ucsbCurriculumService = " + ucsbCurriculumService);
         log.info("convertedSectionCollection = " + convertedSectionCollection);
-        return new UpdateCourseDataWithQuarterJob(quarterYYYYQ, convertedSectionCollection);
+        return new UpdateCourseDataWithQuarterJob(quarterYYYYQ, ucsbSubjectService, ucsbCurriculumService, convertedSectionCollection);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactory.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class UpdateCourseDataWithQuarterJobFactory  {
+
+    @Autowired
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    @Autowired
+    private ConvertedSectionCollection convertedSectionCollection;
+
+    public UpdateCourseDataWithQuarterJob create(String quarterYYYYQ) {
+        log.info("ucsbCurriculumService = " + ucsbCurriculumService);
+        log.info("convertedSectionCollection = " + convertedSectionCollection);
+        return new UpdateCourseDataWithQuarterJob(quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -199,4 +199,19 @@ public class JobsControllerTests extends ControllerTestCase {
         assertNotNull(jobReturned.getStatus());
     }
 
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_update_courses_job_with_quarter() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateCourses?quarterYYYYQ=20231").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -35,6 +35,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
@@ -67,6 +68,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @MockBean
     UCSBCurriculumService ucsbCurriculumService;
+
+    @MockBean
+    UpdateCourseDataWithQuarterJobFactory updateCourseDataWithQuarterJobFactory;
 
     @MockBean
     UpdateCourseDataJobFactory updateCourseDataJobFactory;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -40,6 +40,7 @@ import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.UCSBSubjectsService;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,6 +61,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @Autowired
     ObjectMapper objectMapper;
+
+    @MockBean
+    UCSBSubjectsService ucsbSubjectsService;
 
     @MockBean
     UCSBCurriculumService ucsbCurriculumService;
@@ -203,7 +207,7 @@ public class JobsControllerTests extends ControllerTestCase {
     @Test
     public void admin_can_launch_update_courses_job_with_quarter() throws Exception {
         // act
-        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateCourses?quarterYYYYQ=20231").with(csrf()))
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/updateQuarterCourses?quarterYYYYQ=20231").with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
         // assert

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactoryTests.java
@@ -14,10 +14,14 @@ import org.springframework.context.annotation.Import;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.UCSBSubjectsService;
 
 @RestClientTest(UpdateCourseDataWithQuarterJobFactory.class)
 @AutoConfigureDataJpa
 public class UpdateCourseDataWithQuarterJobFactoryTests {
+
+    @MockBean
+    UCSBSubjectsService ucsbSubjectsService;
 
     @MockBean
     UCSBCurriculumService ucsbCurriculumService;
@@ -38,6 +42,7 @@ public class UpdateCourseDataWithQuarterJobFactoryTests {
         // Assert
 
         assertEquals("20212",updateCourseDataWithQuarterJob.getQuarterYYYYQ());
+        assertEquals(ucsbSubjectsService,updateCourseDataWithQuarterJob.getUcsbSubjectService());
         assertEquals(ucsbCurriculumService,updateCourseDataWithQuarterJob.getUcsbCurriculumService());
         assertEquals(convertedSectionCollection,updateCourseDataWithQuarterJob.getConvertedSectionCollection());
 

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactoryTests.java
@@ -13,8 +13,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
-import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.UCSBSubjectsService;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 
 @RestClientTest(UpdateCourseDataWithQuarterJobFactory.class)
 @AutoConfigureDataJpa

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobFactoryTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+
+@RestClientTest(UpdateCourseDataWithQuarterJobFactory.class)
+@AutoConfigureDataJpa
+public class UpdateCourseDataWithQuarterJobFactoryTests {
+
+    @MockBean
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @Autowired
+    UpdateCourseDataWithQuarterJobFactory updateCourseDataWithQuarterJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+
+        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = updateCourseDataWithQuarterJobFactory.create("20212");
+
+        // Assert
+
+        assertEquals("20212",updateCourseDataWithQuarterJob.getQuarterYYYYQ());
+        assertEquals(ucsbCurriculumService,updateCourseDataWithQuarterJob.getUcsbCurriculumService());
+        assertEquals(convertedSectionCollection,updateCourseDataWithQuarterJob.getConvertedSectionCollection());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobTests.java
@@ -31,11 +31,15 @@ import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.Section;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.UCSBSubjectsService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 public class UpdateCourseDataWithQuarterJobTests {
+
+    @Mock
+    UCSBSubjectsService ucsbSubjectsService;
 
     @Mock
     UCSBCurriculumService ucsbCurriculumService;
@@ -56,7 +60,7 @@ public class UpdateCourseDataWithQuarterJobTests {
 
         List<ConvertedSection> result = coursePage.convertedSections();
 
-        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = new UpdateCourseDataWithQuarterJob("20211", ucsbCurriculumService,
+        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = new UpdateCourseDataWithQuarterJob("20211", ucsbSubjectsService, ucsbCurriculumService,
                 convertedSectionCollection);
 
         when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A"))).thenReturn(result);

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobTests.java
@@ -12,12 +12,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder.LeafNodeBuilderCustomizableContext;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.domain.QAbstractAuditable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -30,8 +33,9 @@ import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 import edu.ucsb.cs156.courses.documents.Section;
 import edu.ucsb.cs156.courses.entities.Job;
-import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.entities.UCSBSubject;
 import edu.ucsb.cs156.courses.services.UCSBSubjectsService;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 
 @ExtendWith(SpringExtension.class)
@@ -60,6 +64,14 @@ public class UpdateCourseDataWithQuarterJobTests {
 
         List<ConvertedSection> result = coursePage.convertedSections();
 
+        List<UCSBSubject> mockList = new ArrayList<UCSBSubject>();
+        mockList.add(new UCSBSubject("CMPSC", "Computer Science", "CMPSC", "ENGR", null, false));
+
+        when(ucsbSubjectsService.get()).thenReturn(mockList);
+  
+
+
+
         UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = new UpdateCourseDataWithQuarterJob("20211", ucsbSubjectsService, ucsbCurriculumService,
                 convertedSectionCollection);
 
@@ -73,11 +85,13 @@ public class UpdateCourseDataWithQuarterJobTests {
         // Assert
 
         String expected = """
+                Updating quarter courses for [20211]
                 Updating courses for [CMPSC 20211]
                 Found 14 sections
                 Storing in MongoDB Collection...
                 14 new sections saved, 0 sections updated, 0 errors
-                Courses for [CMPSC 20211] have been updated""";
+                Courses for [CMPSC 20211] have been updated
+                Quarter courses for [20211] have been updated""";
 
         assertEquals(expected, jobStarted.getLog());
     }
@@ -104,7 +118,15 @@ public class UpdateCourseDataWithQuarterJobTests {
         listWithTwoOrigOneDuplicate.add(section1);
         listWithTwoOrigOneDuplicate.add(section0);
 
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+
+        List<UCSBSubject> mockList = new ArrayList<UCSBSubject>();
+        mockList.add(new UCSBSubject("MATH", "Mathematics", "MATH", "L&S", null, false));
+
+        when(ucsbSubjectsService.get()).thenReturn(mockList);
+
+
+
+        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = new UpdateCourseDataWithQuarterJob("20211", ucsbSubjectsService, ucsbCurriculumService,
                 convertedSectionCollection);
 
         Optional<ConvertedSection> section0Optional = Optional.of(section0);
@@ -124,16 +146,18 @@ public class UpdateCourseDataWithQuarterJobTests {
 
         // Act
 
-        updateCourseDataJob.accept(ctx);
+        updateCourseDataWithQuarterJob.accept(ctx);
 
         // Assert
 
         String expected = """
+                Updating quarter courses for [20211]
                 Updating courses for [MATH 20211]
                 Found 3 sections
                 Storing in MongoDB Collection...
                 2 new sections saved, 1 sections updated, 0 errors
-                Courses for [MATH 20211] have been updated""";
+                Courses for [MATH 20211] have been updated
+                Quarter courses for [20211] have been updated""";
 
         assertEquals(expected, jobStarted.getLog());
     }
@@ -157,7 +181,13 @@ public class UpdateCourseDataWithQuarterJobTests {
 
         listWithOneSection.add(section0);
 
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+        List<UCSBSubject> mockList = new ArrayList<UCSBSubject>();
+        mockList.add(new UCSBSubject("MATH", "Mathematics", "MATH", "L&S", null, false));
+
+        when(ucsbSubjectsService.get()).thenReturn(mockList);
+
+
+        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = new UpdateCourseDataWithQuarterJob("20211", ucsbSubjectsService, ucsbCurriculumService,
                 convertedSectionCollection);
 
         Optional<ConvertedSection> section0Optional = Optional.of(section0);
@@ -172,17 +202,19 @@ public class UpdateCourseDataWithQuarterJobTests {
 
         // Act
 
-        updateCourseDataJob.accept(ctx);
+        updateCourseDataWithQuarterJob.accept(ctx);
 
         // Assert
 
         String expected = """
+                Updating quarter courses for [20211]
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
                 Error saving section: Testing Exception Handling!
                 0 new sections saved, 0 sections updated, 1 errors
-                Courses for [MATH 20211] have been updated""";
+                Courses for [MATH 20211] have been updated
+                Quarter courses for [20211] have been updated""";
 
         assertEquals(expected, jobStarted.getLog());
     }
@@ -213,7 +245,12 @@ public class UpdateCourseDataWithQuarterJobTests {
         updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
         listWithUpdatedSection.add(updatedSection);
 
-        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+        List<UCSBSubject> mockList = new ArrayList<UCSBSubject>();
+        mockList.add(new UCSBSubject("MATH", "Mathematics", "MATH", "L&S", null, false));
+
+        when(ucsbSubjectsService.get()).thenReturn(mockList);
+
+        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = new UpdateCourseDataWithQuarterJob("20211", ucsbSubjectsService, ucsbCurriculumService,
                 convertedSectionCollection);
 
         Optional<ConvertedSection> section0Optional = Optional.of(section0);
@@ -225,16 +262,18 @@ public class UpdateCourseDataWithQuarterJobTests {
 
         // Act
 
-        updateCourseDataJob.accept(ctx);
+        updateCourseDataWithQuarterJob.accept(ctx);
 
         // Assert
 
         String expected = """
+                Updating quarter courses for [20211]
                 Updating courses for [MATH 20211]
                 Found 1 sections
                 Storing in MongoDB Collection...
                 0 new sections saved, 1 sections updated, 0 errors
-                Courses for [MATH 20211] have been updated""";
+                Courses for [MATH 20211] have been updated
+                Quarter courses for [20211] have been updated""";
 
          assertEquals(expected, jobStarted.getLog());
 

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataWithQuarterJobTests.java
@@ -1,0 +1,242 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.documents.Section;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class UpdateCourseDataWithQuarterJobTests {
+
+    @Mock
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @Mock
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @Test
+    void test_log_output_success() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> result = coursePage.convertedSections();
+
+        UpdateCourseDataWithQuarterJob updateCourseDataWithQuarterJob = new UpdateCourseDataWithQuarterJob("20211", ucsbCurriculumService,
+                convertedSectionCollection);
+
+        when(ucsbCurriculumService.getConvertedSections(eq("CMPSC"), eq("20211"), eq("A"))).thenReturn(result);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(result);
+
+        // Act
+
+        updateCourseDataWithQuarterJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [CMPSC 20211]
+                Found 14 sections
+                Storing in MongoDB Collection...
+                14 new sections saved, 0 sections updated, 0 errors
+                Courses for [CMPSC 20211] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_updates() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithTwoOrigOneDuplicate = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        ConvertedSection section1 = convertedSections.get(1);
+
+        listWithTwoOrigOneDuplicate.add(section0);
+        listWithTwoOrigOneDuplicate.add(section1);
+        listWithTwoOrigOneDuplicate.add(section0);
+
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+                convertedSectionCollection);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithTwoOrigOneDuplicate);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional).thenReturn(section0Optional);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section1.getCourseInfo().getQuarter()),
+                eq(section1.getSection().getEnrollCode())))
+                .thenReturn(emptyOptional);
+        when(convertedSectionCollection.saveAll(any())).thenReturn(null);
+
+        // Act
+
+        updateCourseDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [MATH 20211]
+                Found 3 sections
+                Storing in MongoDB Collection...
+                2 new sections saved, 1 sections updated, 0 errors
+                Courses for [MATH 20211] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_log_output_with_errors() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithOneSection = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+
+        listWithOneSection.add(section0);
+
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+                convertedSectionCollection);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+        Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithOneSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(
+                eq(section0.getCourseInfo().getQuarter()),
+                eq(section0.getSection().getEnrollCode())))
+                .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+
+        // Act
+
+        updateCourseDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [MATH 20211]
+                Found 1 sections
+                Storing in MongoDB Collection...
+                Error saving section: Testing Exception Handling!
+                0 new sections saved, 0 sections updated, 1 errors
+                Courses for [MATH 20211] have been updated""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_updating_to_new_values() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+        CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+        List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+        List<ConvertedSection> listWithUpdatedSection = new ArrayList<>();
+
+        ConvertedSection section0 = convertedSections.get(0);
+        String quarter = section0.getCourseInfo().getQuarter();
+        String enrollCode = section0.getSection().getEnrollCode();
+
+        int oldEnrollment = section0.getSection().getEnrolledTotal();
+
+        ConvertedSection updatedSection = (ConvertedSection) section0.clone();
+        updatedSection.getCourseInfo().setTitle("New Title");
+        updatedSection.getSection().setEnrolledTotal(oldEnrollment + 1);
+        listWithUpdatedSection.add(updatedSection);
+
+        UpdateCourseDataJob updateCourseDataJob = new UpdateCourseDataJob("MATH", "20211", ucsbCurriculumService,
+                convertedSectionCollection);
+
+        Optional<ConvertedSection> section0Optional = Optional.of(section0);
+
+        when(ucsbCurriculumService.getConvertedSections(eq("MATH"), eq("20211"), eq("A")))
+                .thenReturn(listWithUpdatedSection);
+        when(convertedSectionCollection.findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode)))
+                .thenReturn(section0Optional);
+
+        // Act
+
+        updateCourseDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+                Updating courses for [MATH 20211]
+                Found 1 sections
+                Storing in MongoDB Collection...
+                0 new sections saved, 1 sections updated, 0 errors
+                Courses for [MATH 20211] have been updated""";
+
+         assertEquals(expected, jobStarted.getLog());
+
+       verify(convertedSectionCollection, times(1)).findOneByQuarterAndEnrollCode(eq(quarter), eq(enrollCode));
+       verify(convertedSectionCollection, times(1)).save(updatedSection);
+
+    }
+
+}


### PR DESCRIPTION
Closes #24 

Add new backend job that takes only a quarter as it's parameter, not a quarter and subjectArea
Inside the job logic, get the list of subject areas, and the iterate through those, making one API call at a time, and then updating the MongoDB database for each one.
It may be helpful to put out a log message for each subject area as it is updated with the number of courses added, updated, and a count of errors.
For testing, you can mock a list of subject areas that is MUCH shorter so that the test log output doesn't have to be super long.
Involves a new Job type, and a new entry in the JobsController.

Jacoco tests passed:
![jacoco](https://user-images.githubusercontent.com/62822602/204654126-93271cbe-28fe-40ae-89bc-e4ad2ea09b99.jpg)

Pitest Mutation tests passed:
![Pitest](https://user-images.githubusercontent.com/62822602/204654178-766e3723-dfcb-45f4-89bf-172b8723e646.jpg)

Heroku successfully deployed:
<img width="1273" alt="image" src="https://user-images.githubusercontent.com/62822602/204656308-3d9b7f22-7f7c-4c92-ab37-cda1ee136385.png">