### PR TITLE
Gianmarco - Fixes UI bug where first use of update courses job fails

### DIFF
--- a/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCoursesJobForm.js
@@ -32,7 +32,7 @@ const UpdateCoursesJobForm = ({ callback }) => {
   );
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
-  const [subject, setSubject] = useState(localSubject || {});
+  const [subject, setSubject] = useState(localSubject || "ANTH");
 
   const handleSubmit = (event) => {
     event.preventDefault();


### PR DESCRIPTION
Closes #35 
Modified: frontend/src/main/components/Jobs/UpdateCoursesJobForm.js

Changes: 
* Modified SubjectArea code to be passed as a string instead of an object to fix URL issue when first deploying.
* Tested recent branch on localhost and qa site and received no error message.

To Test:
* Use incognito/private browsing window and  go to the Admin/Manage Jobs page
* Update course job without changing the subject filter (default should be ANTH)
* If there is no error, the bug has been fixed


