### PR TITLE
IH - Add Course-Over-Time search page, & Section-Over-Time table

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,8 @@ import SectionSearchesIndexPage from "main/pages/SectionSearches/SectionSearches
 import CoursesIndexPage from "main/pages/Courses/PSCourseIndexPage";
 import CoursesCreatePage from "main/pages/Courses/PSCourseCreatePage";
 
+import CourseOverTimeIndexPage from "main/pages/CourseOverTime/CourseOverTimeIndexPage";
+
 function App() {
 
   const { data: currentUser } = useCurrentUser();
@@ -53,6 +55,7 @@ function App() {
           )
         }
         <Route exact path="/coursedescriptions/search" element={<CourseDescriptionIndexPage />} />
+        <Route exact path="/courseovertime/search" element={<CourseOverTimeIndexPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/fixtures/sectionOverTimeFixtures.js
+++ b/frontend/src/fixtures/sectionOverTimeFixtures.js
@@ -1,0 +1,417 @@
+export const oneSection = [
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "12583",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 84,
+          "maxEnroll": 100,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1930",
+              "building": "BUCHN",
+              "roomCapacity": "100",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    }
+]
+
+export const sixSections = [
+    {
+      "courseInfo": {
+        "quarter": "20222",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08078",
+        "section": "0100",
+        "session": null,
+        "classClosed": "Y",
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 51,
+        "maxEnroll": 77,
+        "secondaryStatus": "R",
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "1902",
+            "building": "PSYCH",
+            "roomCapacity": "77",
+            "days": " T R   ",
+            "beginTime": "09:30",
+            "endTime": "10:45"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "LOKSHTANOV D",
+            "functionCode": "Teaching and in charge"
+          }
+        ]
+      }
+    },
+    {
+      "courseInfo": {
+        "quarter": "20222",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08086",
+        "section": "0101",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 9,
+        "maxEnroll": 24,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "1445",
+            "building": "PHELP",
+            "roomCapacity": "35",
+            "days": "    F  ",
+            "beginTime": "09:00",
+            "endTime": "09:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "TURNLUND K K",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      }
+    },
+    {
+      "courseInfo": {
+        "quarter": "20222",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08094",
+        "section": "0102",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 18,
+        "maxEnroll": 22,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "2108",
+            "building": "GIRV",
+            "roomCapacity": "36",
+            "days": "    F  ",
+            "beginTime": "10:00",
+            "endTime": "10:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "DE A",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      }
+    },
+    {
+      "courseInfo": {
+        "quarter": "20222",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08102",
+        "section": "0103",
+        "session": null,
+        "classClosed": "Y",
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 24,
+        "maxEnroll": 31,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "1116",
+            "building": "GIRV",
+            "roomCapacity": "42",
+            "days": "    F  ",
+            "beginTime": "11:00",
+            "endTime": "11:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "SHAFIUZZAMAN",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      }
+    },
+    {
+      "courseInfo": {
+        "quarter": "20221",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08128",
+        "section": "0100",
+        "session": null,
+        "classClosed": "Y",
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 80,
+        "maxEnroll": 100,
+        "secondaryStatus": "R",
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "1171",
+            "building": "CHEM",
+            "roomCapacity": "113",
+            "days": " T R   ",
+            "beginTime": "12:30",
+            "endTime": "13:45"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "SINGH A K",
+            "functionCode": "Teaching and in charge"
+          }
+        ]
+      }
+    },
+    {
+      "courseInfo": {
+        "quarter": "20221",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08136",
+        "section": "0101",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 19,
+        "maxEnroll": 34,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "1448",
+            "building": "PHELP",
+            "roomCapacity": "35",
+            "days": "    F  ",
+            "beginTime": "09:00",
+            "endTime": "09:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "DANESHAMOOZ J",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "KILGORE J D",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "YANG YIFAN",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      }
+    },
+    {
+      "courseInfo": {
+        "quarter": "20221",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08144",
+        "section": "0102",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 30,
+        "maxEnroll": 33,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "2532",
+            "building": "PHELP",
+            "roomCapacity": "40",
+            "days": "    F  ",
+            "beginTime": "10:00",
+            "endTime": "10:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "DANESHAMOOZ J",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "KILGORE J D",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "YANG YIFAN",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      }
+    },
+    {
+      "courseInfo": {
+        "quarter": "20221",
+        "courseId": "CMPSC   130A -1",
+        "title": "DATA STRUCT ALGOR",
+        "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications."
+      },
+      "section": {
+        "enrollCode": "08151",
+        "section": "0103",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 31,
+        "maxEnroll": 33,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "2123",
+            "building": "GIRV",
+            "roomCapacity": "42",
+            "days": "    F  ",
+            "beginTime": "11:00",
+            "endTime": "11:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "KILGORE J D",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "DANESHAMOOZ J",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "YANG YIFAN",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      }
+    }
+  ]
+

--- a/frontend/src/fixtures/sectionOverTimeFixtures.js
+++ b/frontend/src/fixtures/sectionOverTimeFixtures.js
@@ -415,3 +415,653 @@ export const sixSections = [
     }
   ]
 
+export const gigaSections = [
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "12583",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 84,
+          "maxEnroll": 100,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1930",
+              "building": "BUCHN",
+              "roomCapacity": "100",
+              "days": "T R    ",
+              "beginTime": "15:00",
+              "endTime": "16:15"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "12554",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 19,
+          "maxEnroll": 20,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1445",
+              "building": "PHELP",
+              "roomCapacity": "20",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "12699",
+          "section": "0102",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 15,
+          "maxEnroll": 20,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1214",
+              "building": "HSSB",
+              "roomCapacity": "20",
+              "days": "M      ",
+              "beginTime": "16:00",
+              "endTime": "16:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "TAH L T",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20222",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "14432",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 99,
+          "maxEnroll": 100,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1930",
+              "building": "BUCHN",
+              "roomCapacity": "100",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "TANG P R",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20222",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "32555",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 32,
+          "maxEnroll": 33,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1920",
+              "building": "GRVTZ",
+              "roomCapacity": "33",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20222",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "29241",
+          "section": "0102",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 19,
+          "maxEnroll": 25,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1212",
+              "building": "HSSB",
+              "roomCapacity": "20",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20214",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "12583",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 84,
+          "maxEnroll": 100,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1930",
+              "building": "BUCHN",
+              "roomCapacity": "100",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20214",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "12543",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 84,
+          "maxEnroll": 100,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1930",
+              "building": "BUCHN",
+              "roomCapacity": "100",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20214",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "23442",
+          "section": "0102",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 3,
+          "maxEnroll": 4,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1930",
+              "building": "BUCHN",
+              "roomCapacity": "100",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20212",
+          "courseId": "ECE       1A -1",
+          "title": "COMP ENGR SEMINAR",
+          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+        },
+        "section": {
+          "enrollCode": "12583",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 84,
+          "maxEnroll": 100,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": null,
+          "restrictionMajor": "+PRCME+CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1930",
+              "building": "BUCHN",
+              "roomCapacity": "100",
+              "days": "M      ",
+              "beginTime": "15:00",
+              "endTime": "15:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "WANG L C",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    }
+]
+
+export const fiveSections = [
+    {
+        "courseInfo": {
+          "quarter": "20222",
+          "courseId": "ECE       5  -1",
+          "title": "INTRO TO ECE",
+          "description": "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment."
+        },
+        "section": {
+          "enrollCode": "12591",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 85,
+          "maxEnroll": 80,
+          "secondaryStatus": "R",
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "L",
+          "restrictionMajor": "+EE   +CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1260",
+              "building": "PHELP",
+              "roomCapacity": "90",
+              "days": "M W    ",
+              "beginTime": "15:30",
+              "endTime": "16:45"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "HESPANHA J P",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       5  -1",
+          "title": "INTRO TO ECE",
+          "description": "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment."
+        },
+        "section": {
+          "enrollCode": "12591",
+          "section": "0100",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 84,
+          "maxEnroll": 80,
+          "secondaryStatus": "R",
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "L",
+          "restrictionMajor": "+EE   +CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1260",
+              "building": "PHELP",
+              "roomCapacity": "90",
+              "days": "M W    ",
+              "beginTime": "15:30",
+              "endTime": "16:45"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "HESPANHA J P",
+              "functionCode": "Teaching and in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       5  -1",
+          "title": "INTRO TO ECE",
+          "description": "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment."
+        },
+        "section": {
+          "enrollCode": "12609",
+          "section": "0101",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 21,
+          "maxEnroll": 21,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "L",
+          "restrictionMajor": "+EE   +CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1124",
+              "building": "HFH",
+              "roomCapacity": null,
+              "days": "    F  ",
+              "beginTime": "12:00",
+              "endTime": "14:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "YUNG A S",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       5  -1",
+          "title": "INTRO TO ECE",
+          "description": "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment."
+        },
+        "section": {
+          "enrollCode": "12617",
+          "section": "0102",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 21,
+          "maxEnroll": 21,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "L",
+          "restrictionMajor": "+EE   +CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1124",
+              "building": "HFH",
+              "roomCapacity": null,
+              "days": " T     ",
+              "beginTime": "17:00",
+              "endTime": "19:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "SANCHEZ C D",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        }
+    },
+    {
+        "courseInfo": {
+          "quarter": "20221",
+          "courseId": "ECE       5  -1",
+          "title": "INTRO TO ECE",
+          "description": "Aims at exposing freshmen students to the different sub-fields within Electrical   and Computer   Engineering. Composed of lectures by different faculty members and a weekly   laboratory based   on projects that are executed using the Arduino environment."
+        },
+        "section": {
+          "enrollCode": "12625",
+          "section": "0103",
+          "session": null,
+          "classClosed": null,
+          "courseCancelled": null,
+          "gradingOptionCode": null,
+          "enrolledTotal": 21,
+          "maxEnroll": 21,
+          "secondaryStatus": null,
+          "departmentApprovalRequired": false,
+          "instructorApprovalRequired": false,
+          "restrictionLevel": "L",
+          "restrictionMajor": "+EE   +CMPEN",
+          "restrictionMajorPass": null,
+          "restrictionMinor": null,
+          "restrictionMinorPass": null,
+          "concurrentCourses": [],
+          "timeLocations": [
+            {
+              "room": "1124",
+              "building": "HFH",
+              "roomCapacity": null,
+              "days": "    F  ",
+              "beginTime": "09:00",
+              "endTime": "11:50"
+            }
+          ],
+          "instructors": [
+            {
+              "instructor": "YUNG A S",
+              "functionCode": "Teaching but not in charge"
+            }
+          ]
+        }
+    }
+]

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -78,6 +78,11 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               </NavDropdown>
             </Nav>
 
+            <Nav className="mr-auto">
+              <NavDropdown title="Course History" id="appnavbar-course-over-time-dropdown" data-testid="appnavbar-course-over-time-dropdown" >
+                <NavDropdown.Item href="/courseovertime/search" data-testid="appnavbar-course-over-time-search">Search</NavDropdown.Item>
+              </NavDropdown>
+            </Nav>
 
 
             

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -1,0 +1,119 @@
+import SectionsOverTimeTableBase from "main/components/SectionsOverTimeTableBase";
+
+import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
+
+
+function getFirstVal(values) {
+    return values[0];
+};
+
+function getCourseId(courseIds) {
+    return courseIds[0].substring(0, courseIds[0].length - 2);
+}
+
+export default function SectionsOverTimeTable({ sections }) {
+
+
+    // Stryker enable all 
+    // Stryker disable BooleanLiteral
+    const columns = [
+        {
+            Header: 'Quarter',
+            accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
+            disableGroupBy: true,
+            id: 'quarter',
+
+            Cell: ({ cell: { value } }) => value
+
+        },
+        {
+            Header: 'Course ID',
+            accessor: 'courseInfo.courseId',
+            disableGroupBy: true,
+
+            aggregate: getCourseId,
+            Aggregated: ({ cell: { value } }) => `${value}`,
+
+            Cell: ({ cell: { value } }) => value.substring(0, value.length - 2)
+        },
+        {
+            Header: 'Title',
+            accessor: 'courseInfo.title',
+            disableGroupBy: true,
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+            Header: 'Is Section?',
+            accessor: (row) => isSection(row.section.section),
+            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+            id: 'isSection',
+        },
+        {
+            Header: 'Enrolled',
+            accessor: (row) => convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+            disableGroupBy: true,
+            id: 'enrolled',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Location',
+            accessor: (row) => formatLocation(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'location',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Days',
+            accessor: (row) => formatDays(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'days',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Time',
+            accessor: (row) => formatTime(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'time',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Instructor',
+            accessor: (row) => formatInstructors(row.section.instructors),
+            disableGroupBy: true,
+            id: 'instructor',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },        
+        {
+            Header: 'Enroll Code',
+            accessor: 'section.enrollCode', 
+            disableGroupBy: true,
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        }
+    ];
+
+    const testid = "SectionsOverTimeTable";
+
+    const columnsToDisplay = columns;
+
+    return <SectionsOverTimeTableBase
+        data={sections}
+        columns={columnsToDisplay}
+        testid={testid}
+    />;
+};

--- a/frontend/src/main/components/SectionsOverTimeTableBase.js
+++ b/frontend/src/main/components/SectionsOverTimeTableBase.js
@@ -1,0 +1,74 @@
+import React from "react";
+import { useTable, useGroupBy, useExpanded } from 'react-table'
+import { Table } from "react-bootstrap";
+
+
+// Stryker disable StringLiteral, ArrayDeclaration
+export default function SectionsOverTimeTableBase({ columns, data, testid = "testid"}) {
+  
+  // Stryker disable next-line ObjectLiteral
+  const {getTableProps, getTableBodyProps, headerGroups, rows, prepareRow} = useTable({initialState: {groupBy: ["quarter"], hiddenColumns: ["isSection"]}, columns, data }, useGroupBy, useExpanded)
+
+  return (
+    <Table {...getTableProps()} striped bordered hover >
+      <thead>
+        {headerGroups.map(headerGroup => (
+          <tr {...headerGroup.getHeaderGroupProps()}>
+            {headerGroup.headers.map(column => (
+              <th
+                {...column.getHeaderProps()}
+                data-testid={`${testid}-header-${column.id}`}
+              >
+                {column.render('Header')}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()}>
+        {rows.map(row => {
+          prepareRow(row)
+          return (
+            <>
+            {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[3].value) ? 
+            <tr {...row.getRowProps()}>
+              {row.cells.map((cell, _index) => {
+                return (
+                    <td
+                    {...cell.getCellProps()}
+                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
+                    // Stryker disable next-line ObjectLiteral
+                    style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
+                    >
+                    
+                    {cell.isGrouped ? (
+                    <>
+                    <span {...row.getToggleRowExpandedProps()}
+                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
+                    >
+                    {row.isExpanded ? "➖ " : "➕ "}
+                    </span>{" "}
+                    {cell.render("Cell")} 
+                    </>
+                    ) 
+                    : cell.isAggregated ? (
+                      cell.render("Aggregated")
+                    )
+                    : cell.render('Cell')
+                    }
+                    <>
+                    
+                    </>
+                  </td>
+                )
+              })}
+
+            </tr>
+            : null}
+            </>
+          )
+        })}
+      </tbody>
+    </Table>
+  )
+}

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import CourseOverTimeSearchForm from "main/components/BasicCourseSearch/CourseOverTimeSearchForm";
+import BasicCourseTable from "main/components/Courses/BasicCourseTable";
+import { useBackendMutation } from "main/utils/useBackend";
+
+export default function CourseDescriptionIndexPage() {
+  // Stryker disable next-line all : Can't test state because hook is internal
+  const [courseJSON, setCourseJSON] = useState([]);
+
+  const objectToAxiosParams = (query) => ({
+    url: "/api/public/courseovertime/search",
+    params: {
+      startQtr: query.startQuarter,
+      endQtr: query.endQuarter,
+      subjectArea: query.subject,
+      courseNumber: query.courseNumber + query.courseSuf,
+    },
+  });
+
+  const onSuccess = (courses) => {
+    setCourseJSON(courses.classes);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    []
+  );
+
+  async function fetchCourseOverTimeJSON(_event, query) {
+    mutation.mutate(query);
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h5>Welcome to the UCSB Course History Search!</h5>
+        <CourseOverTimeSearchForm fetchJSON={fetchCourseOverTimeJSON} />
+        <BasicCourseTable courses={courseJSON} />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CourseOverTimeSearchForm from "main/components/BasicCourseSearch/CourseOverTimeSearchForm";
-import BasicCourseTable from "main/components/Courses/BasicCourseTable";
 import { useBackendMutation } from "main/utils/useBackend";
+import SectionsTable from "main/components/Sections/SectionsTable";
 
 export default function CourseDescriptionIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -19,7 +19,7 @@ export default function CourseDescriptionIndexPage() {
   });
 
   const onSuccess = (courses) => {
-    setCourseJSON(courses.classes);
+    setCourseJSON(courses);
   };
 
   const mutation = useBackendMutation(
@@ -38,7 +38,7 @@ export default function CourseDescriptionIndexPage() {
       <div className="pt-2">
         <h5>Welcome to the UCSB Course History Search!</h5>
         <CourseOverTimeSearchForm fetchJSON={fetchCourseOverTimeJSON} />
-        <BasicCourseTable courses={courseJSON} />
+        <SectionsTable sections={courseJSON} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -2,9 +2,9 @@ import { useState } from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CourseOverTimeSearchForm from "main/components/BasicCourseSearch/CourseOverTimeSearchForm";
 import { useBackendMutation } from "main/utils/useBackend";
-import SectionsTable from "main/components/Sections/SectionsTable";
+import SectionsOverTimeTable from "main/components/Sections/SectionsOverTimeTable";
 
-export default function CourseDescriptionIndexPage() {
+export default function CourseOverTimeIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
   const [courseJSON, setCourseJSON] = useState([]);
 
@@ -38,7 +38,7 @@ export default function CourseDescriptionIndexPage() {
       <div className="pt-2">
         <h5>Welcome to the UCSB Course History Search!</h5>
         <CourseOverTimeSearchForm fetchJSON={fetchCourseOverTimeJSON} />
-        <SectionsTable sections={courseJSON} />
+        <SectionsOverTimeTable sections={courseJSON} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/components/Sections/SectionOverTimeTable.stories.js
+++ b/frontend/src/stories/components/Sections/SectionOverTimeTable.stories.js
@@ -1,0 +1,34 @@
+
+import React from 'react';
+
+import SectionsOverTimeTable from "main/components/Sections/SectionsOverTimeTable";
+import { oneSection, sixSections } from 'fixtures/sectionOverTimeFixtures';
+
+export default {
+    title: 'components/Sections/SectionsOverTimeTable',
+    component: SectionsOverTimeTable
+};
+
+const Template = (args) => {
+    return (
+        <SectionsOverTimeTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    sections: []
+};
+
+export const OneSection = Template.bind({});
+
+OneSection.args = {
+    sections: oneSection
+};
+
+export const SixSections = Template.bind({});
+
+SixSections.args = {
+    sections: sixSections
+};

--- a/frontend/src/stories/pages/CourseOverTimeIndexPage.stories.js
+++ b/frontend/src/stories/pages/CourseOverTimeIndexPage.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import CourseOverTimeIndexPage from "main/pages/CourseOverTime/CourseOverTimeIndexPage";
+import { threeSections } from "fixtures/sectionFixtures"
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
+import { ucsbSubjectsFixtures } from 'fixtures/ucsbSubjectsFixtures';
+import { apiCurrentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'pages/CourseOverTimeIndexPage',
+    component: CourseOverTimeIndexPage,
+    parameters: {
+        mockData: [
+            {
+                url: '/api/UCSBSubjects/all',
+                method: 'GET',
+                status: 200,
+                response: ucsbSubjectsFixtures.threeSubjects
+            },
+            {
+                url: '/api/public/courseovertime/search',
+                method: 'GET',
+                status: 200,
+                response: threeSections
+            },
+            {
+                url: '/api/systemInfo',
+                method: 'GET',
+                status: 200,
+                response: systemInfoFixtures.showingBoth
+            },
+            {
+                url: '/api/currentUser',
+                method: 'GET',
+                status: 200,
+                response: apiCurrentUserFixtures.adminUser
+            },
+        ]
+    }
+};
+
+const Template = () => <CourseOverTimeIndexPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -214,4 +214,27 @@ describe("AppNavbar tests", () => {
 
         expect(await screen.findByTestId("appnavbar-course-descriptions-search")).toBeInTheDocument();
     });
+
+    test("renders the Course History/Course Over Time menu correctly", async () => {
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("appnavbar-course-over-time-dropdown")).toBeInTheDocument();
+        const dropdown = screen.getByTestId("appnavbar-course-over-time-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+
+        expect(await screen.findByTestId("appnavbar-course-over-time-search")).toBeInTheDocument();
+    });
 });

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -1,0 +1,150 @@
+import {  fireEvent, render, screen } from "@testing-library/react";
+import { sixSections } from "fixtures/sectionOverTimeFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import SectionsOverTimeTable from "main/components/Sections/SectionsOverTimeTable";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("Section tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={[]} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+
+
+  test("Has the expected cell values when expanded", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={sixSections} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
+    const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
+    const testId = "SectionsOverTimeTable";
+    
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-quarter-expand-symbols`)
+    fireEvent.click(expandRow);
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("S22");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("9:30 AM - 10:45 AM");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("T R");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("51/77");
+    expect(screen.getByTestId(`${testId}-cell-row-5-col-location`)).toHaveTextContent("PHELP 1448");
+    expect(screen.getByTestId(`${testId}-cell-row-5-col-instructor`)).toHaveTextContent("DANESHAMOOZ J, KILGORE J D, YANG YIFAN");
+    expect(screen.getByTestId(`${testId}-cell-row-5-col-courseInfo.courseId`)).not.toHaveTextContent("CMPSC 130A -1");
+  });
+
+  test("Has the expected column headers and content", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={sixSections} />
+        </MemoryRouter>
+      </QueryClientProvider>
+      );
+
+      const expectedHeaders = ["Quarter",  "Course ID", "Title", "Enrolled", "Location", "Days", "Time", "Instructor", "Enroll Code"];
+      const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "enrolled", "location", "days", "time", "instructor", "section.enrollCode"];
+      const testId = "SectionsOverTimeTable";
+
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+
+
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 130A");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).not.toHaveTextContent("CMPSC 130A -1")
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`)).toHaveTextContent("DATA STRUCT ALGOR");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("S22");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("9:30 AM - 10:45 AM");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-days`)).toHaveTextContent("T R");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("51/77");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-location`)).toHaveTextContent("PSYCH 1902");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-instructor`)).toHaveTextContent("LOKSHTANOV D");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`)).toHaveTextContent("08078");
+      
+
+  });
+
+  test("Correctly groups separate quarters of the same class", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={sixSections} />
+        </MemoryRouter>
+      </QueryClientProvider>
+      );
+    
+      const testId = "SectionsOverTimeTable"
+
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("S22");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-quarter`)).toHaveTextContent("W22");
+
+      const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-quarter-expand-symbols`)
+      fireEvent.click(expandRow);
+
+
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-quarter`)).toHaveTextContent("W22");
+  })
+
+  test("First dropdown is different than last dropdown", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={sixSections} />
+        </MemoryRouter>
+      </QueryClientProvider>
+      );
+
+      const testId = "SectionsOverTimeTable"
+
+      const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-quarter-expand-symbols`)
+      fireEvent.click(expandRow);
+
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("51/77");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-enrolled`)).toHaveTextContent("80/100");
+  });
+
+
+});
+

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -1,5 +1,5 @@
 import {  fireEvent, render, screen } from "@testing-library/react";
-import { sixSections } from "fixtures/sectionOverTimeFixtures";
+import { fiveSections, sixSections, gigaSections } from "fixtures/sectionOverTimeFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import SectionsOverTimeTable from "main/components/Sections/SectionsOverTimeTable";
@@ -110,28 +110,28 @@ describe("Section tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <SectionsOverTimeTable sections={sixSections} />
+          <SectionsOverTimeTable sections={gigaSections} />
         </MemoryRouter>
       </QueryClientProvider>
       );
     
       const testId = "SectionsOverTimeTable"
 
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("S22");
-      expect(screen.getByTestId(`${testId}-cell-row-1-col-quarter`)).toHaveTextContent("W22");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W22");
+      expect(screen.getByTestId(`${testId}-cell-row-3-col-quarter`)).toHaveTextContent("S21");
 
       const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-quarter-expand-symbols`)
       fireEvent.click(expandRow);
 
 
-      expect(screen.getByTestId(`${testId}-cell-row-1-col-quarter`)).toHaveTextContent("W22");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-quarter`)).toHaveTextContent("S22");
   })
 
   test("First dropdown is different than last dropdown", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <SectionsOverTimeTable sections={sixSections} />
+          <SectionsOverTimeTable sections={fiveSections} />
         </MemoryRouter>
       </QueryClientProvider>
       );
@@ -141,8 +141,8 @@ describe("Section tests", () => {
       const expandRow = screen.getByTestId(`${testId}-cell-row-1-col-quarter-expand-symbols`)
       fireEvent.click(expandRow);
 
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("51/77");
-      expect(screen.getByTestId(`${testId}-cell-row-1-col-enrolled`)).toHaveTextContent("80/100");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-enrolled`)).toHaveTextContent("84/80");
+      expect(screen.getByTestId(`${testId}-cell-row-2-col-enrolled`)).toHaveTextContent("21/21");
   });
 
 

--- a/frontend/src/tests/components/SectionsOverTimeTableBase.test.js
+++ b/frontend/src/tests/components/SectionsOverTimeTableBase.test.js
@@ -13,6 +13,10 @@ describe("SectionsOverTimeTableBase tests", () => {
             accessor: 'col2',
         },
         //add groupable columns
+        {
+            Header: 'Groupable',
+            accessor: 'quarter',
+        },
     ];
     
     test("renders an empty table without crashing", () => {
@@ -20,4 +24,6 @@ describe("SectionsOverTimeTableBase tests", () => {
             <SectionsOverTimeTableBase columns={columns} data={[]} group={false} />
         );
     });
+
+    
 })

--- a/frontend/src/tests/components/SectionsOverTimeTableBase.test.js
+++ b/frontend/src/tests/components/SectionsOverTimeTableBase.test.js
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import SectionsOverTimeTableBase from "main/components/SectionsOverTimeTableBase";
+
+describe("SectionsOverTimeTableBase tests", () => {
+
+    const columns = [
+        {
+            Header: 'Column 1',
+            accessor: 'col1', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Column 2',
+            accessor: 'col2',
+        },
+        //add groupable columns
+    ];
+    
+    test("renders an empty table without crashing", () => {
+        render(
+            <SectionsOverTimeTableBase columns={columns} data={[]} group={false} />
+        );
+    });
+})

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
@@ -24,7 +24,7 @@ jest.mock('react-toastify', () => {
 
 describe("CourseOverTimeIndexPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    const axiosMock =new AxiosMockAdapter(axios);
     
     beforeEach(() => {
         axiosMock.resetHistory();
@@ -47,7 +47,7 @@ describe("CourseOverTimeIndexPage tests", () => {
         );
     });
 
-    test("calls UCSB Course over time search api correctly with 1 section response", async () => {
+    test("calls UCSB Course over time search api correctly with 3 section response", async () => {
         axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
         axiosMock
             .onGet("/api/public/courseovertime/search")

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import CourseOverTimeIndexPage from "main/pages/CourseOverTime/CourseOverTimeIndexPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { threeSections } from "fixtures/sectionFixtures";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+import userEvent from "@testing-library/user-event";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("CourseOverTimeIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    
+    beforeEach(() => {
+        axiosMock.resetHistory();
+        axiosMock
+            .onGet("/api/currentUser")
+            .reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock
+            .onGet("/api/systemInfo")
+            .reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <CourseOverTimeIndexPage />
+            </MemoryRouter>
+        </QueryClientProvider>
+        );
+    });
+
+    test("calls UCSB Course over time search api correctly with 1 section response", async () => {
+        axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+        axiosMock
+            .onGet("/api/public/courseovertime/search")
+            .reply(200, threeSections);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CourseOverTimeIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const selectStartQuarter = screen.getByLabelText("Start Quarter");
+        userEvent.selectOptions(selectStartQuarter, "20222");
+        const selectEndQuarter = screen.getByLabelText("End Quarter");
+        userEvent.selectOptions(selectEndQuarter, "20222");
+        const selectSubject = screen.getByLabelText("Subject Area");
+        
+
+        const expectedKey = "CourseOverTimeSearch.Subject-option-ANTH";
+        await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
+        
+        userEvent.selectOptions(selectSubject, "ANTH");
+        const enterCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A')")
+        userEvent.type(enterCourseNumber, "130A");
+
+        const submitButton = screen.getByText("Submit");
+        expect(submitButton).toBeInTheDocument();
+        userEvent.click(submitButton);
+
+        axiosMock.resetHistory();
+
+        await waitFor(() => {
+            expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+        });
+
+        expect(axiosMock.history.get[0].params).toEqual({
+            startQtr: "20222",
+            endQtr: "20222",
+            subjectArea: "ANTH",
+            courseNumber: "130A",
+        });
+
+        expect(screen.getByText("ECE 1A")).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Closes #29 

Implements the `CourseOverTimeIndexPage` which has a search form (implemented in #43) and a Section Table.
The new `SectionsOverTimeTable` groups sections by quarter, rather than by course ID (as the regular `SectionsTable` does).

e.g.
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/20908336/204688540-46caeb1a-cd55-4d14-a548-257d31049ef0.png">

`SectionsOverTimeTable` storybook:
https://ucsb-cs156-f22.github.io/f22-5pm-courses-docs-qa/storybook-qa/ih-courseOverTimePage/?path=/docs/components-sections-sectionsovertimetable--empty

`CourseOverTimeIndexPage` storybook:
https://ucsb-cs156-f22.github.io/f22-5pm-courses-docs-qa/storybook-qa/ih-courseOverTimePage/?path=/docs/pages-courseovertimeindexpage--default
